### PR TITLE
Document milestone execution details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo 11 Real-Time Mission Simulator
 
-This repository has been reset to develop a real-time Apollo 11 mission simulator that can run both as a browser-based proof of concept and, eventually, as a Nintendo 64 experience. All design goals and roadmap details live in [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md).
+This repository has been reset to develop a real-time Apollo 11 mission simulator that can run both as a browser-based proof of concept and, eventually, as a Nintendo 64 experience. All design goals and roadmap details live in [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md), with milestone-specific execution notes collected under [`docs/milestones/`](docs/milestones).
 
 ## Repository Layout
 - `js/` – Workspace for the JavaScript/Web prototype that will validate the mission model and user experience.
@@ -8,9 +8,14 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - `docs/` – Planning and reference material for the project, including the current mission and technology plan.
 
 ## Immediate Priorities
-1. Build out documentation and data ingestion (Flight Plan, Flight Journal, Mission Operations Report).
-2. Prototype the deterministic mission scheduler, resource models, and PTC control loop in the JS build.
-3. Use the prototype to tune event windows, failure cascades, and HUD feedback before targeting the N64 platform.
+1. Complete Milestone M0 by transforming the Flight Plan, Flight Journal, and Mission Operations Report into normalized CSV packs as outlined in [`docs/milestones/M0_DATA_INGESTION.md`](docs/milestones/M0_DATA_INGESTION.md).
+2. Stand up Milestone M1 core systems—scheduler, resource models, and Passive Thermal Control loop—per [`docs/milestones/M1_CORE_SYSTEMS.md`](docs/milestones/M1_CORE_SYSTEMS.md).
+3. Use the JS prototype to tune event windows, failure cascades, and HUD feedback before targeting the N64 platform.
+
+## Documentation Map
+- [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md) – High-level scope, pillars, and mission milestones.
+- [`docs/milestones/M0_DATA_INGESTION.md`](docs/milestones/M0_DATA_INGESTION.md) – Historical data ingestion workflow and schemas.
+- [`docs/milestones/M1_CORE_SYSTEMS.md`](docs/milestones/M1_CORE_SYSTEMS.md) – Core engine, scheduler, and Passive Thermal Control specification.
 
 ## Contribution Notes
 - Follow the guidelines in [`AGENTS.md`](AGENTS.md) for documentation structure and future implementation phases.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -90,8 +90,10 @@ Each event has a window, manual inputs, autopilot scripts, telemetry, and failur
 - Design-side unit tests for PAD logic and failure cascades.
 
 ## 11. Milestones
-1. **M0:** Historical ingestion and event CSV creation.
-2. **M1:** Core engine (loop, scheduler, resources, PTC).
+Supporting details for each milestone live in [`docs/milestones/`](milestones).
+
+1. **M0:** Historical ingestion and event CSV creation (see [`milestones/M0_DATA_INGESTION.md`](milestones/M0_DATA_INGESTION.md)).
+2. **M1:** Core engine (loop, scheduler, resources, PTC) documented in [`milestones/M1_CORE_SYSTEMS.md`](milestones/M1_CORE_SYSTEMS.md).
 3. **M2:** Guidance and RCS (burn execution, docking minigame).
 4. **M3:** UI/HUD and audio.
 5. **M4:** N64 port and performance tuning.

--- a/docs/milestones/M0_DATA_INGESTION.md
+++ b/docs/milestones/M0_DATA_INGESTION.md
@@ -1,0 +1,98 @@
+# Milestone M0 — Historical Ingestion & Event Data Creation
+
+Milestone M0 bootstraps the simulator with structured mission data extracted from the Apollo 11 primary sources. The objective is to deliver normalized CSV packs and reference notes that later milestones can consume without revisiting the raw material.
+
+## Deliverables
+- Canonical Apollo 11 timeline anchored to Ground Elapsed Time (GET) in one-minute resolution.
+- Event CSV describing mission beats, prerequisites, autopilot hooks, and failure consequences.
+- Checklist CSV mirroring the Apollo 11 Flight Plan and supporting callouts.
+- PAD uplink dataset for guidance, burns, and consumables updates.
+- Provenance log linking each derived record to its page/paragraph in the source documents.
+
+## Source Inventory
+| Source | Coverage | Notes |
+| --- | --- | --- |
+| Apollo 11 Flight Plan (Final) | Timelines, checklists, crew cues | Primary driver for event sequencing and procedure text. |
+| Apollo 11 Flight Journal | Narrative timeline, GET anchors, voice transcripts | Use to cross-check durations, callouts, and anomaly notes. |
+| Mission Operations Report | Burn performance, MCC schedules, trajectory data | Supplies tolerances, Δv budgets, and midcourse windows. |
+| Systems handbooks & MOCR notes | Subsystem limitations, fault responses | Useful for failure taxonomy elaboration. |
+
+## Ingestion Pipeline
+1. **Digitize & OCR** — Ensure all PDFs have searchable text; correct OCR artifacts around GET stamps, degrees, and checklist numbering.
+2. **Timeline Extraction** — Build a spreadsheet keyed by GET in `HHH:MM:SS` capturing start/stop times for each procedure. Use Flight Plan as baseline and annotate differences observed in Flight Journal.
+3. **Checklist Breakdown** — Split checklists into atomic steps. Each entry keeps: `checklist_id`, `step_number`, `action`, `expected_response`, `crew_role`, `reference`.
+4. **PAD Parsing** — Extract PAD cards (TLI, MCC, LOI, TEI, etc.) into structured fields: `pad_id`, `purpose`, `GET_delivery`, `parameters`, `valid_until`, `source_ref`.
+5. **Autopilot Script Hooks** — Flag steps where autopilot or guidance programs engage. Record necessary parameters (e.g., `PGM`, `target_attitude`, `thrust_profile`).
+6. **Failure Notes** — Capture conditions and resulting penalties directly from Flight Journal and MOCR. Map them to `failure_id` entries for later simulation hooks.
+7. **Export CSVs** — Convert the curated sheets into machine-readable CSV packs stored under `docs/data/` (to be created during M0 execution).
+8. **Validation Sweep** — Run scripts to verify chronological ordering, dependency closure, and GET uniqueness. Spot-check against published GET anchors (TLI 002:44:14, LOI 075:50:00, Landing 102:45:40).
+
+## Data Schemas
+
+### Events (`events.csv`)
+| Field | Description |
+| --- | --- |
+| `event_id` | Unique identifier (`phase_sequence`, e.g., `TLI_001`). |
+| `phase` | High-level phase label (`Launch`, `Translunar`, `LOI`, etc.). |
+| `get_open` / `get_close` | Earliest/latest GET window for the event. |
+| `craft` | `CSM`, `LM`, or `Joint`. |
+| `system` | Subsystem focus (`Guidance`, `Power`, `Comms`, `Thermal`, `Navigation`). |
+| `prerequisites` | Comma-delimited `event_id`s that must be completed. |
+| `autopilot_script` | Optional reference to `autopilots.csv`. |
+| `checklist_id` | Links to the crew checklist steps. |
+| `success_effects` | Δ-resource outcomes when within tolerance (JSON blob). |
+| `failure_effects` | Consequences when missed or late (JSON blob referencing `failure_id`). |
+| `notes` | Freeform clarifications or voice call excerpts. |
+
+### Checklists (`checklists.csv`)
+| Field | Description |
+| --- | --- |
+| `checklist_id` | Identifier tied to Flight Plan section (e.g., `FP_2-8`). |
+| `title` | Human-readable name. |
+| `GET_nominal` | Nominal GET for reference. |
+| `crew_role` | `CDR`, `CMP`, `LMP`, `Joint`. |
+| `step_number` | Sequential step index. |
+| `action` | The command or verification performed. |
+| `expected_response` | Anticipated meter/indicator result. |
+| `reference` | Source citation (page/paragraph). |
+
+### Autopilot Scripts (`autopilots.csv`)
+| Field | Description |
+| --- | --- |
+| `autopilot_id` | Identifier (`PGM_06_TLI`). |
+| `description` | Summary of the maneuver. |
+| `script_path` | Relative path to JSON script with detailed time/thrust points. |
+| `entry_conditions` | Required craft state before engagement. |
+| `termination_conditions` | Condition to exit the script (Δv met, GET limit, manual abort). |
+| `tolerances` | Acceptable deviation ranges for scoring and failure evaluation. |
+
+### Failures (`failures.csv`)
+| Field | Description |
+| --- | --- |
+| `failure_id` | Unique identifier for linking from events. |
+| `classification` | `Recoverable`, `Hard`, or `Technical`. |
+| `trigger` | Condition that causes the failure. |
+| `immediate_effect` | Instantaneous outcome (e.g., `Δv_margin -= 10`). |
+| `ongoing_penalty` | Time-based degradation. |
+| `recovery_actions` | Steps the crew may take. |
+| `source_ref` | Provenance citation. |
+
+## Output Structure
+- `docs/data/events.csv`
+- `docs/data/checklists.csv`
+- `docs/data/autopilots.csv`
+- `docs/data/failures.csv`
+- `docs/data/pads.csv`
+- `docs/data/provenance.md`
+
+Each CSV should include a header row, adhere to UTF-8, and avoid Excel artifacts (smart quotes, tabs). `provenance.md` lists each dataset row range with citations (Flight Plan page, Journal entry time).
+
+## Tooling Recommendations
+- Use a lightweight Python ingestion script (`scripts/ingest/` to be created later) to convert annotated spreadsheets into CSV, preserving GET formatting and verifying dependencies.
+- Adopt unit-style checks that confirm: monotonically increasing GET within phases, valid references between events/checklists/failures, and PAD times falling inside corresponding event windows.
+- Commit the ingestion notebooks or scripts alongside the CSV exports for reproducibility.
+
+## Acceptance Criteria
+- All milestone deliverables exist and pass validation scripts without manual edits.
+- Sample queries ("find all events blocking LOI", "list all power-related failures during translunar coast") can be answered directly from the CSVs.
+- The project README references the data location and ingestion approach for contributors joining after M0.

--- a/docs/milestones/M1_CORE_SYSTEMS.md
+++ b/docs/milestones/M1_CORE_SYSTEMS.md
@@ -1,0 +1,83 @@
+# Milestone M1 — Core Engine, Scheduler, and Passive Thermal Control
+
+Milestone M1 stands up the deterministic simulation core that the rest of the project depends on. The milestone concludes when the JS prototype can march forward in real time, execute scheduled events, and maintain the Passive Thermal Control (PTC) maneuver using resource-aware control loops.
+
+## Objectives
+- Implement a fixed-step simulation loop (20 Hz) with deterministic ordering of system updates.
+- Load the M0 CSV datasets and materialize runtime data structures for events, checklists, autopilot scripts, and failure definitions.
+- Provide an event scheduler that enforces prerequisites, GET windows, and branching outcomes.
+- Model first-pass resource systems (power, propellant, thermal, communications) with budget tracking and failure hooks.
+- Implement the PTC control loop with both manual assist and autopilot maintenance.
+- Expose a minimal HUD readout for GET, upcoming events, and key resource margins.
+
+## Core Loop Architecture
+```
+initialize_state();
+while (simulation_running) {
+  advance_time(dt);                // dt = 1/20s
+  poll_inputs();                   // manual crew actions or automation toggles
+  update_event_scheduler();        // activate/complete events based on GET and prerequisites
+  apply_autopilot_scripts();       // feed thrust/attitude commands from active scripts
+  integrate_guidance_and_physics();// RK2 for translation; PD for attitude with RCS quantization
+  update_resources();              // power, propellant, thermal, comm windows
+  evaluate_failures();             // check for penalties and state transitions
+  refresh_hud();                   // push current state to UI layer
+}
+```
+Key properties:
+- **Deterministic ordering:** updates happen in the exact order above. All randomness must be seeded through mission config files.
+- **Discrete inputs:** manual crew steps are queued with the GET at which they occur; the scheduler processes them during the `update_event_scheduler` pass.
+- **Time anchoring:** `advance_time` increments both Mission Elapsed Time (MET) and GET, using the launch GET reference from configuration.
+
+## Runtime Data Structures
+- **Events:** Load into a dictionary keyed by `event_id` with fields mirroring `events.csv`. Runtime fields include `status` (`Pending`, `Armed`, `Active`, `Complete`, `Failed`, `Skipped`) and `activation_time`.
+- **Checklists:** Store as ordered lists under each `checklist_id`. Manual completion toggles occur when crew input matches the expected `action`/`response` pair.
+- **Autopilot scripts:** Parse JSON payloads referenced by `script_path` into sequences of time-tagged commands (attitude targets, throttle levels, entry/exit conditions).
+- **Failures:** Represent as evaluators that receive the current simulation state and return penalty deltas when triggered.
+
+## Event Scheduler Behavior
+1. **Arming:** When all prerequisites succeed and `GET >= get_open`, the event moves from `Pending` to `Armed`.
+2. **Activation:** Events become `Active` when crew input or autopilot engagement begins, or automatically at `get_open` if flagged `auto_start`.
+3. **Completion:** Upon satisfying success criteria (checklist steps complete, autopilot script exit condition met) within `get_close`, mark `Complete` and apply `success_effects` to resources.
+4. **Failure:** If `get_close` passes without completion, or a linked failure condition triggers, mark `Failed`, apply `failure_effects`, and enqueue follow-on penalties (e.g., additional Δv required).
+5. **Skip/Override:** Developer tools may mark events `Skipped` for Free Flight mode. Skipped events log a provenance entry but do not affect prerequisites unless flagged `critical`.
+
+Events publish status updates to the HUD queue so the UI can render upcoming windows, active tasks, and overdue penalties.
+
+## Resource Models (First Pass)
+- **Power:** Track fuel cell output, battery state of charge, and load draw. Inputs come from checklists (switch configurations) and event effects. Failure thresholds: low reactant reserves, fuel cell ΔP.
+- **Propellant:** Distinguish SPS, RCS (CSM & LM), and ascent/descent stage prop. Autopilot scripts consume prop at defined rates with stochastic jitter disabled for determinism.
+- **Thermal:** Represent PTC as a regulating mechanism for `heat_balance` derived from sun exposure. Without PTC, cryo boiloff increases, feeding back into power reserves.
+- **Communications:** Windows encode DSN station availability and orientation requirements. Missed windows delay PAD deliveries and can escalate failure classes for time-critical updates.
+
+Each resource exposes interfaces for `apply_delta(value, source)` and emits alerts when thresholds cross caution/warning bands. These alerts feed both the scheduler (to trigger remedial events) and the HUD (for player awareness).
+
+## PTC Control Loop Specification
+- **Objective:** Maintain a slow 0.3°/s roll to evenly distribute heating and preserve cryo tanks.
+- **Sensors:** Current attitude quaternion, sun vector, roll rate gyros.
+- **Controller:** PD controller with quantized RCS pulses (0.5 s minimum). Gains tuned to avoid limit cycling.
+- **Autopilot Behavior:**
+  - Entry: verify craft is out of burns and communications windows permit rotation.
+  - Engage: fire RCS jets to reach target roll rate, then schedule pulse trains to maintain rate.
+  - Monitor: integrate thermal model; if cryo boiloff trend exceeds threshold, increase duty cycle.
+  - Exit: triggered by upcoming burns, checklists, or manual abort.
+- **Manual Assist:** Crew can fire discrete pulses; the controller updates its state estimate accordingly to prevent fighting pilot inputs.
+
+PTC status becomes an event in the scheduler with success criteria "roll rate within tolerance for 95% of the monitoring window". Failure injects a `thermal_drift` penalty and increases power draw via elevated boiloff.
+
+## HUD & Telemetry Hooks
+- **Time Block:** Display GET, MET, and time to next critical event.
+- **Event Stack:** Show top N `Armed`/`Active` events with colored status indicators and deadlines.
+- **Resources:** Render gauges for power (SOA %, reactant minutes), propellant (per tank), thermal balance, and comm window countdown.
+- **PTC Widget:** Visualize roll rate vs. target with caution/warning bands.
+- **Log Feed:** Append scheduler messages (event start/end, failures, autopilot transitions) for debugging and eventual voiceover alignment.
+
+The HUD can be console-based during M1—rendered as a simple text grid updated each frame—before migrating to a graphical display in later milestones.
+
+## Validation & Testing
+- **Determinism Check:** Run the same 6-hour mission slice twice and confirm byte-identical state logs.
+- **Resource Drift Test:** Simulate PTC off vs. on and verify expected divergence in cryo/power reserves after 3 hours.
+- **Event Ordering Test:** Ensure prerequisites prevent out-of-order activation by injecting deliberate delays.
+- **Failure Trigger Test:** Force the PTC failure condition and validate that downstream events (e.g., "Shedding Loads") arm correctly.
+
+Passing these validations signals readiness to move into Milestone M2 for guidance and docking mechanics.

--- a/js/README.md
+++ b/js/README.md
@@ -2,7 +2,7 @@
 
 This folder will host the web-based proof of concept for the Apollo 11 mission simulator. Initial objectives:
 
-1. Implement the deterministic mission scheduler and event data ingestion described in the project plan.
+1. Implement the deterministic mission scheduler and event data ingestion described in the project plan and expanded in the milestone notes for [M0](../docs/milestones/M0_DATA_INGESTION.md) and [M1](../docs/milestones/M1_CORE_SYSTEMS.md).
 2. Build a lightweight UI that surfaces GET, upcoming events, and resource states.
 3. Prototype physics, guidance, and failure cascades to validate balancing before porting to N64.
 

--- a/n64/README.md
+++ b/n64/README.md
@@ -4,8 +4,8 @@ The N64 build will reuse the systems proven in the JS prototype while targeting 
 
 Key preparation tasks:
 
-- Define data formats that the fixed-step engine can load efficiently from cartridge or ROM.
+- Define data formats that the fixed-step engine can load efficiently from cartridge or ROM, reusing the CSV schemas produced during Milestone M0 (see [`../docs/milestones/M0_DATA_INGESTION.md`](../docs/milestones/M0_DATA_INGESTION.md)).
 - Outline rendering constraints for wireframe/line-based scenes and HUD overlays.
-- Plan controller mappings, save infrastructure, and performance budgets as captured in the project plan.
+- Plan controller mappings, save infrastructure, and performance budgets as captured in the project plan and informed by the scheduler/loop specification for Milestone M1 ([`../docs/milestones/M1_CORE_SYSTEMS.md`](../docs/milestones/M1_CORE_SYSTEMS.md)).
 
 Implementation will begin after the prototype establishes validated mission data and control loops.


### PR DESCRIPTION
## Summary
- add milestone documentation outlining M0 data ingestion workflow and schemas
- capture M1 core engine, scheduler, and PTC control loop design details
- update repository readmes to reference new milestone notes and documentation map

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c9e0786428832391c9b722fb5176fc