### PR TITLE
Document milestone M3 UI and audio plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,20 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 ## Current Progress
 - Milestone M0 datasets now cover launch through splashdown, capturing extended Passive Thermal Control maintenance, MCC-1/2/3/4 PAD workflows, LOI-focused navigation realignments, DOI planning, LM separation, powered descent and landing safing, ascent/docking evaluation, TEI preparation and execution, MCC-5 return corrections, entry PAD alignment, service module jettison, and recovery procedures.
 - Milestone M2 planning notes outline guidance, RCS, and docking system requirements in [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) to steer upcoming implementation work.
+- Milestone M3 UI, HUD, and audio telemetry planning in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) defines presentation-layer architecture, cue taxonomy, and accessibility handoff targets for the JS prototype and N64 port.
 
 ## Immediate Priorities
 1. Continue Milestone M0 by transforming the Flight Plan, Flight Journal, and Mission Operations Report into normalized CSV packs as outlined in [`docs/milestones/M0_DATA_INGESTION.md`](docs/milestones/M0_DATA_INGESTION.md), focusing on surface EVA expansions, transearth communications, and validation tooling.
 2. Stand up Milestone M1 core systems—scheduler, resource models, and Passive Thermal Control loop—per [`docs/milestones/M1_CORE_SYSTEMS.md`](docs/milestones/M1_CORE_SYSTEMS.md).
 3. Prepare for Milestone M2 execution by deriving thruster configuration tables, validating autopilot script needs, and planning rendezvous tuning sessions following [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md).
+4. Capture Milestone M3 presentation-layer requirements by prototyping HUD layouts, audio cue routing, and accessibility tooling as described in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md).
 
 ## Documentation Map
 - [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md) – High-level scope, pillars, and mission milestones.
 - [`docs/milestones/M0_DATA_INGESTION.md`](docs/milestones/M0_DATA_INGESTION.md) – Historical data ingestion workflow and schemas.
 - [`docs/milestones/M1_CORE_SYSTEMS.md`](docs/milestones/M1_CORE_SYSTEMS.md) – Core engine, scheduler, and Passive Thermal Control specification.
 - [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) – Guidance execution, RCS modelling, and docking gameplay plan.
+- [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) – UI, HUD, audio telemetry, and accessibility planning for the prototype and N64 targets.
 - [`docs/data/README.md`](docs/data/README.md) – Normalized mission datasets produced during Milestone M0 (currently covering launch through splashdown).
 
 ## Contribution Notes

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -95,7 +95,7 @@ Supporting details for each milestone live in [`docs/milestones/`](milestones).
 1. **M0:** Historical ingestion and event CSV creation (see [`milestones/M0_DATA_INGESTION.md`](milestones/M0_DATA_INGESTION.md)).
 2. **M1:** Core engine (loop, scheduler, resources, PTC) documented in [`milestones/M1_CORE_SYSTEMS.md`](milestones/M1_CORE_SYSTEMS.md).
 3. **M2:** Guidance and RCS (burn execution, docking minigame) documented in [`milestones/M2_GUIDANCE_RCS.md`](milestones/M2_GUIDANCE_RCS.md).
-4. **M3:** UI/HUD and audio.
+4. **M3:** UI/HUD and audio presentation planning captured in [`milestones/M3_UI_AUDIO.md`](milestones/M3_UI_AUDIO.md).
 5. **M4:** N64 port and performance tuning.
 6. **M5:** Content pass for full Apollo 11 mission graph.
 7. **M6:** Fidelity pass aligning to GET anchors.

--- a/docs/milestones/M3_UI_AUDIO.md
+++ b/docs/milestones/M3_UI_AUDIO.md
@@ -1,0 +1,89 @@
+# Milestone M3 — UI, HUD, and Audio Telemetry
+
+Milestone M3 layers a mission-ready presentation stack onto the deterministic simulator delivered in M1 and the guidance/RCS
+systems planned for M2. The milestone concludes when the JS prototype can visualize the mission timeline, resources, and vehicle
+state in real time while emitting audio cues, logs, and accessibility affordances that prepare the content pipeline for the N64
+port.
+
+## Objectives
+- Build a modular UI architecture that consumes scheduler/resource state and renders prioritized mission context at 20 Hz.
+- Expose checklist, event, and failure feedback loops through HUD widgets, log feeds, and developer tooling.
+- Establish the audio event pipeline, including historical callouts, caution/warning tones, and configurable alert routing.
+- Document cross-platform considerations so the eventual N64 build can reproduce the UI and audio layer within its budgets.
+
+## Deliverables
+- UI state aggregator and presentation layer design notes for the JS prototype (component tree, update cadence, data bindings).
+- HUD layout specifications including timing blocks, event stack, resource gauges, and maneuver widgets.
+- Audio cue taxonomy mapped to mission events and failure classes with playback priority rules and asset references.
+- Logging, replay, and accessibility guidelines covering color use, captioning, and control remapping hooks.
+
+## UI Architecture & Data Flow
+1. **State aggregation:**
+   - Subscribe to scheduler, resource, autopilot, and failure evaluators introduced in M1/M2.
+   - Normalize updates into a single `ui_frame` payload with timestamps, active events, resource deltas, checklist progress, and
+     active maneuvers.
+   - Guarantee deterministic ordering by applying mutations during the simulation loop’s `refresh_hud` pass.
+2. **Component layers:**
+   - **Core HUD:** Static layout sized for 320×240, rendering via HTML/CSS/Canvas in the JS build and line primitives on N64.
+   - **Overlays:** Contextual widgets (docking reticle, burn monitor, entry corridor) toggled by scheduler signals.
+   - **Console feed:** Scrollback buffer capturing event activations, autopilot transitions, failure breadcrumbs, and PAD
+     deliveries. Include filtering toggles for debugging vs. player mode.
+3. **Data bindings & performance:**
+   - Use immutable snapshots or diffed updates to avoid tearing at 20 Hz.
+   - Document expected update sizes so the N64 renderer can budget DMA bandwidth for HUD vertices/textures.
+
+### HUD Layout Guidelines
+| Module | Content | Notes |
+| --- | --- | --- |
+| Time Block | GET, MET, countdown to next critical event | Syncs to scheduler anchors, supports pause/time compression indicators. |
+| Event Stack | Top 3–5 armed/active events with status, deadline, checklist link | Color-code by risk (nominal, caution, overdue); include autopilot engagement iconography. |
+| Resource Gauges | Power, propellant (per tank), thermal margin, comm window timer | Use consistent units and caution/warning bands derived from resource model thresholds. |
+| Maneuver Widget | Burn/attitude/PTC telemetry, Δv remaining, attitude error | Switch between burn, PTC, rendezvous, or entry modes based on scheduler flags. |
+| Checklist Pane | Active checklist title, current step, expected response | Support manual step acknowledgement with keyboard/controller bindings. |
+| Failure Alerts | Caution/warning summary with breadcrumbs | Link back to console log entries and recommended recovery actions. |
+
+### Interaction & Accessibility Considerations
+- Provide keyboard/controller shortcuts for checklist step acknowledgement, HUD tab cycling, and log filtering.
+- Support color-blind-friendly palettes and high-contrast mode toggles.
+- Offer optional text-to-speech or caption overlays for major audio cues in the JS prototype; document N64 feasibility (e.g.,
+  limited ROM for voice playback vs. text subtitles).
+
+## Audio Pipeline & Cue Taxonomy
+1. **Cue categories:**
+   - **Ambient bed:** Cabin hum, radio static loops keyed to craft mode.
+   - **Mission callouts:** Historical CapCom dialogue for major events (e.g., "Go for TLI") with timing offsets from the dataset.
+   - **Alerts:** Caution/warning tones, master alarm, guidance program change beeps.
+   - **UI feedback:** Button/select sounds, checklist acknowledgement ticks.
+2. **Event wiring:**
+   - Extend the mission data packs with cue IDs (`audio_cue` fields in events/failures) without altering schema yet; document the
+     proposed columns and JSON bindings for later ingestion scripts.
+   - Build a dispatcher that consumes scheduler/failure notifications and enqueues cues with priority (alerts > callouts >
+     ambience > UI).
+   - Support ducking rules so alerts temporarily attenuate ambience and voice playback.
+3. **Asset pipeline:**
+   - JS prototype: Use Web Audio API with preloaded buffers, dynamic gain nodes for ducking, and sample-accurate scheduling.
+   - N64 port: Target ADPCM-compressed mono assets, 22.05 kHz sampling, streaming via libdragon’s audio DMA. Budget memory for
+     simultaneous playback (e.g., 3 concurrent cues + ambience).
+   - Document naming conventions, loudness targets (-16 LUFS integrated), and loop point definitions to streamline conversion.
+
+## Logging, Replay, and Developer Tooling
+- Extend the existing mission log format to include UI focus changes, audio cue triggers, and checklist interactions with GET
+  stamps.
+- Provide a replay mode that consumes recorded logs to validate HUD/audio behavior without re-running the full simulation.
+- Define debug overlays (frame time graph, resource delta inspector) that can be toggled independently of the player HUD.
+- Capture profiling metrics (render time, audio queue depth) each minute to confirm budgets before porting to the N64.
+
+## Validation & Acceptance Criteria
+- Run a six-hour translunar slice and verify the HUD refreshes deterministically with no dropped frames or stale data.
+- Trigger PTC, MCC, LOI, and docking sequences to confirm contextual overlays appear/disappear according to scheduler flags.
+- Fire representative failure hooks (power margin low, comm blackout) and ensure alerts play with correct priority and visual
+  emphasis.
+- Validate that audio ducking and simultaneous cue playback stay within headroom limits (no clipping, <1 dB gain overshoot).
+- Confirm replay logs reproduce identical HUD states and audio cue order when re-run.
+
+## Dependencies & Handoff
+- Requires the scheduler, resource models, autopilot runners, and docking logic from M1/M2.
+- Outputs UI/audio specifications, cue mappings, and tooling that Milestone M4 (N64 port) will translate into libdragon
+  render/audio code.
+- Document outstanding gaps (e.g., missing voice assets, accessibility stretch goals) for prioritization during M5 content
+  integration.

--- a/js/README.md
+++ b/js/README.md
@@ -3,7 +3,7 @@
 This folder will host the web-based proof of concept for the Apollo 11 mission simulator. Initial objectives:
 
 1. Implement the deterministic mission scheduler and event data ingestion described in the project plan and expanded in the milestone notes for [M0](../docs/milestones/M0_DATA_INGESTION.md) and [M1](../docs/milestones/M1_CORE_SYSTEMS.md).
-2. Build a lightweight UI that surfaces GET, upcoming events, and resource states.
-3. Prototype physics, guidance, and failure cascades to validate balancing before porting to N64.
+2. Build a lightweight UI that surfaces GET, upcoming events, and resource states following the presentation roadmap in [M3](../docs/milestones/M3_UI_AUDIO.md).
+3. Prototype physics, guidance, and failure cascades—including the rendezvous and docking flow scoped in [M2](../docs/milestones/M2_GUIDANCE_RCS.md)—to validate balancing before porting to N64.
 
 Until the simulation code exists, keep this directory focused on documentation, data definitions, and small prototypes.

--- a/n64/README.md
+++ b/n64/README.md
@@ -6,6 +6,7 @@ Key preparation tasks:
 
 - Define data formats that the fixed-step engine can load efficiently from cartridge or ROM, reusing the CSV schemas produced during Milestone M0 (see [`../docs/milestones/M0_DATA_INGESTION.md`](../docs/milestones/M0_DATA_INGESTION.md)).
 - Outline rendering constraints for wireframe/line-based scenes and HUD overlays.
+- Mirror the UI/HUD and audio telemetry plan captured in [`../docs/milestones/M3_UI_AUDIO.md`](../docs/milestones/M3_UI_AUDIO.md) while budgeting for 320×240 output, libdragon audio DMA, and Controller Pak storage of accessibility toggles.
 - Plan controller mappings, save infrastructure, and performance budgets as captured in the project plan and informed by the scheduler/loop specification for Milestone M1 ([`../docs/milestones/M1_CORE_SYSTEMS.md`](../docs/milestones/M1_CORE_SYSTEMS.md)).
 
 Implementation will begin after the prototype establishes validated mission data and control loops.


### PR DESCRIPTION
## Summary
- add milestone guidance for the UI, HUD, and audio telemetry track
- link the new planning doc throughout the project plan and platform readmes
- refresh repository README priorities to include the M3 presentation-layer focus

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9fcd20b188323ac05110af2e60f4e