### PR TITLE
Add JS simulation harness and update milestone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 
 ## Current Progress
 - Milestone M0 datasets now cover launch through splashdown, capturing extended Passive Thermal Control maintenance, MCC-1/2/3/4 PAD workflows, LOI-focused navigation realignments, DOI planning, LM separation, powered descent and landing safing, ascent/docking evaluation, TEI preparation and execution, MCC-5 return corrections, entry PAD alignment, service module jettison, and recovery procedures.
+- Milestone M1 CLI prototype in [`js/src/index.js`](js/src/index.js) ingests the mission datasets, drives the deterministic scheduler/resource loop, and logs Passive Thermal Control drift to support upcoming HUD/audio work.
 - Milestone M2 planning notes outline guidance, RCS, and docking system requirements in [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) to steer upcoming implementation work.
 - Milestone M3 UI, HUD, and audio telemetry planning in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) defines presentation-layer architecture, cue taxonomy, and accessibility handoff targets for the JS prototype and N64 port.
 - Milestone M4 N64 port plan in [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) maps the libdragon architecture, rendering/audio budgets, input scheme, and asset pipeline for the hardware build.
 
 ## Immediate Priorities
 1. Continue Milestone M0 by transforming the Flight Plan, Flight Journal, and Mission Operations Report into normalized CSV packs as outlined in [`docs/milestones/M0_DATA_INGESTION.md`](docs/milestones/M0_DATA_INGESTION.md), focusing on surface EVA expansions, transearth communications, and validation tooling.
-2. Stand up Milestone M1 core systems—scheduler, resource models, and Passive Thermal Control loop—per [`docs/milestones/M1_CORE_SYSTEMS.md`](docs/milestones/M1_CORE_SYSTEMS.md).
+2. Grow the Milestone M1 simulation harness with manual checklist acknowledgement, detailed consumable budgets, and deterministic log replay built on the new CLI prototype.
 3. Prepare for Milestone M2 execution by deriving thruster configuration tables, validating autopilot script needs, and planning rendezvous tuning sessions following [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md).
 4. Capture Milestone M3 presentation-layer requirements by prototyping HUD layouts, audio cue routing, and accessibility tooling as described in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md).
 

--- a/js/README.md
+++ b/js/README.md
@@ -1,9 +1,32 @@
 # JS Prototype Workspace
 
-This folder will host the web-based proof of concept for the Apollo 11 mission simulator. Initial objectives:
+This workspace now includes a Node.js simulation harness that exercises the Apollo 11 mission datasets produced during Milestone M0. The prototype focuses on the Milestone M1 goals of deterministic scheduling, Passive Thermal Control (PTC) feedback, and resource bookkeeping before a browser UI is introduced.
 
-1. Implement the deterministic mission scheduler and event data ingestion described in the project plan and expanded in the milestone notes for [M0](../docs/milestones/M0_DATA_INGESTION.md) and [M1](../docs/milestones/M1_CORE_SYSTEMS.md).
-2. Build a lightweight UI that surfaces GET, upcoming events, and resource states following the presentation roadmap in [M3](../docs/milestones/M3_UI_AUDIO.md).
-3. Prototype physics, guidance, and failure cascades—including the rendezvous and docking flow scoped in [M2](../docs/milestones/M2_GUIDANCE_RCS.md)—to validate balancing before porting to N64.
+## Current Prototype Features
+- Loads `docs/data/*.csv` and autopilot JSON packs into typed runtime structures (`src/data/missionDataLoader.js`).
+- Runs a fixed-step (20 Hz by default) mission loop that arms, activates, and completes events based on prerequisites and GET windows (`src/sim/eventScheduler.js`, `src/sim/simulation.js`).
+- Applies success/failure effects into a lightweight resource model with thermal drift modelling for PTC coverage (`src/sim/resourceSystem.js`).
+- Streams mission log messages with GET stamps for later HUD/audio wiring (`src/logging/missionLogger.js`).
 
-Until the simulation code exists, keep this directory focused on documentation, data definitions, and small prototypes.
+## Running the Prototype
+```
+npm start -- --until 015:00:00
+```
+
+The `--until` flag accepts a `HHH:MM:SS` GET target; omit it to simulate the first 15 hours automatically. Additional flags:
+- `--tick-rate <hz>` – Override the simulation frequency (default `20`).
+- `--log-interval <seconds>` – How often to emit aggregate resource snapshots (default `3600`).
+- `--quiet` – Suppress per-event logging while still printing the final summary.
+
+## Module Overview
+- `src/index.js` – CLI entrypoint that wires the loader, scheduler, resource model, and simulation loop.
+- `src/data/missionDataLoader.js` – CSV/JSON ingestion with autopilot duration estimation and checklist/failure maps.
+- `src/sim/eventScheduler.js` – Handles prerequisite gating, activation, completion, and failure effects.
+- `src/sim/resourceSystem.js` – Tracks power/thermal deltas, Passive Thermal Control status, and failure hooks.
+- `src/utils/` – Helpers for GET parsing and CSV decoding without external dependencies.
+
+## Next Steps
+- Integrate manual/checklist inputs so non-autopilot events respect crew acknowledgement instead of auto-completing.
+- Expand the resource model to differentiate SPS, RCS, and electrical budgets, wiring in PAD-driven consumable deltas.
+- Surface the scheduler/resource state through a browser HUD per Milestone M3, keeping the CLI loop as a regression harness.
+- Add deterministic log replay tests that validate event ordering, PTC drift divergence, and failure propagation.

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "apollo11-sim-js",
+  "version": "0.1.0",
+  "description": "JS prototype for the Apollo 11 real-time mission simulator",
+  "type": "module",
+  "scripts": {
+    "start": "node ./src/index.js",
+    "check": "node --check ./src/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {},
+  "license": "MIT"
+}

--- a/js/src/config/paths.js
+++ b/js/src/config/paths.js
@@ -1,0 +1,9 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const JS_ROOT = path.resolve(__dirname, '..', '..');
+export const PROJECT_ROOT = path.resolve(JS_ROOT, '..');
+export const DATA_DIR = path.resolve(PROJECT_ROOT, 'docs', 'data');

--- a/js/src/data/missionDataLoader.js
+++ b/js/src/data/missionDataLoader.js
@@ -1,0 +1,186 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { parseCsv } from '../utils/csv.js';
+import { parseGET } from '../utils/time.js';
+
+export async function loadMissionData(dataDir, { logger } = {}) {
+  const files = await Promise.all([
+    readFile(path.resolve(dataDir, 'events.csv')),
+    readFile(path.resolve(dataDir, 'checklists.csv')),
+    readFile(path.resolve(dataDir, 'autopilots.csv')),
+    readFile(path.resolve(dataDir, 'failures.csv')),
+    readFile(path.resolve(dataDir, 'pads.csv')),
+  ]);
+
+  const [eventsContent, checklistsContent, autopilotsContent, failuresContent, padsContent] = files;
+
+  const autopilotRecords = parseCsv(autopilotsContent);
+  const autopilotEntries = await Promise.all(
+    autopilotRecords.map(async (record) => {
+      const script = await loadAutopilotScript(dataDir, record.script_path, logger);
+      return [
+        record.autopilot_id,
+        {
+          id: record.autopilot_id,
+          description: record.description,
+          scriptPath: record.script_path,
+          entryConditions: record.entry_conditions,
+          terminationConditions: record.termination_conditions,
+          tolerances: parseOptionalJson(record.tolerances),
+          script,
+          durationSeconds: computeAutopilotDuration(script),
+        },
+      ];
+    }),
+  );
+  const autopilots = new Map(autopilotEntries);
+
+  const eventRecords = parseCsv(eventsContent);
+  const events = eventRecords.map((record) => ({
+    id: record.event_id,
+    phase: record.phase,
+    getOpenSeconds: parseGET(record.get_open),
+    getCloseSeconds: parseGET(record.get_close),
+    craft: record.craft,
+    system: record.system,
+    prerequisites: parseList(record.prerequisites),
+    autopilotId: record.autopilot_script || null,
+    checklistId: record.checklist_id || null,
+    successEffects: parseOptionalJson(record.success_effects),
+    failureEffects: parseOptionalJson(record.failure_effects),
+    notes: record.notes ?? '',
+  }));
+  events.sort((a, b) => (a.getOpenSeconds ?? Infinity) - (b.getOpenSeconds ?? Infinity));
+
+  const checklistRecords = parseCsv(checklistsContent);
+  const checklists = buildChecklists(checklistRecords);
+  const failures = buildLookup(parseCsv(failuresContent), 'failure_id');
+  const pads = buildLookup(parseCsv(padsContent), 'pad_id');
+
+  if (logger) {
+    logger.log(0, 'Mission data loaded', {
+      counts: {
+        events: events.length,
+        checklists: checklists.size,
+        autopilots: autopilots.size,
+        failures: failures.size,
+        pads: pads.size,
+      },
+    });
+  }
+
+  return {
+    events,
+    checklists,
+    autopilots,
+    failures,
+    pads,
+  };
+}
+
+async function readFile(filePath) {
+  return fs.readFile(filePath, 'utf8');
+}
+
+async function loadAutopilotScript(dataDir, relativePath, logger) {
+  if (!relativePath) {
+    return null;
+  }
+
+  const absolute = path.resolve(dataDir, relativePath);
+  try {
+    const content = await fs.readFile(absolute, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    if (logger) {
+      logger.log(0, `Failed to load autopilot script ${relativePath}`, {
+        error: error.message,
+      });
+    }
+    return null;
+  }
+}
+
+function parseOptionalJson(value) {
+  if (!value) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return {};
+  }
+}
+
+function parseList(value) {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function computeAutopilotDuration(script) {
+  if (!script || !Array.isArray(script.sequence)) {
+    return 0;
+  }
+
+  let maxTime = 0;
+  for (const step of script.sequence) {
+    const time = Number(step.time ?? 0);
+    const duration = Number(step.duration ?? 0);
+    const end = (Number.isFinite(time) ? time : 0) + (Number.isFinite(duration) ? duration : 0);
+    if (end > maxTime) {
+      maxTime = end;
+    }
+  }
+  return maxTime;
+}
+
+function buildChecklists(records) {
+  const map = new Map();
+
+  for (const record of records) {
+    if (!record.checklist_id) {
+      continue;
+    }
+    if (!map.has(record.checklist_id)) {
+      map.set(record.checklist_id, {
+        id: record.checklist_id,
+        title: record.title,
+        crewRole: record.crew_role,
+        nominalGetSeconds: parseGET(record.GET_nominal),
+        steps: [],
+      });
+    }
+    const checklist = map.get(record.checklist_id);
+    checklist.steps.push({
+      stepNumber: Number.parseInt(record.step_number, 10) || checklist.steps.length + 1,
+      action: record.action,
+      expectedResponse: record.expected_response,
+      reference: record.reference,
+    });
+  }
+
+  for (const checklist of map.values()) {
+    checklist.steps.sort((a, b) => a.stepNumber - b.stepNumber);
+  }
+
+  return map;
+}
+
+function buildLookup(records, keyField) {
+  const map = new Map();
+  for (const record of records) {
+    const key = record[keyField];
+    if (!key) {
+      continue;
+    }
+    map.set(key, record);
+  }
+  return map;
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { DATA_DIR } from './config/paths.js';
+import { loadMissionData } from './data/missionDataLoader.js';
+import { MissionLogger } from './logging/missionLogger.js';
+import { EventScheduler } from './sim/eventScheduler.js';
+import { ResourceSystem } from './sim/resourceSystem.js';
+import { Simulation } from './sim/simulation.js';
+import { formatGET, parseGET } from './utils/time.js';
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const logger = new MissionLogger({ silent: args.quiet });
+
+  logger.log(0, 'Initializing mission simulation prototype', {
+    dataDir: DATA_DIR,
+    tickRate: args.tickRate,
+  });
+
+  const missionData = await loadMissionData(DATA_DIR, { logger });
+
+  const resourceSystem = new ResourceSystem(logger, {
+    logIntervalSeconds: args.logIntervalSeconds,
+  });
+  const scheduler = new EventScheduler(
+    missionData.events,
+    missionData.autopilots,
+    resourceSystem,
+    logger,
+    {
+      checklists: missionData.checklists,
+      failures: missionData.failures,
+    },
+  );
+
+  const simulation = new Simulation({
+    scheduler,
+    resourceSystem,
+    logger,
+    tickRate: args.tickRate,
+  });
+
+  const untilSeconds = args.untilSeconds ?? parseGET('015:00:00');
+  logger.log(0, `Running simulation until GET ${formatGET(untilSeconds)}`);
+
+  const summary = simulation.run({ untilGetSeconds: untilSeconds });
+  printSummary(summary);
+}
+
+function parseArgs(argv) {
+  const args = {
+    quiet: false,
+    tickRate: 20,
+    logIntervalSeconds: 3600,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--until': {
+        const next = argv[i + 1];
+        if (!next) {
+          throw new Error('--until requires a GET value (e.g., 015:00:00)');
+        }
+        const parsed = parseGET(next);
+        if (parsed == null) {
+          throw new Error(`Invalid GET format for --until: ${next}`);
+        }
+        args.untilSeconds = parsed;
+        i += 1;
+        break;
+      }
+      case '--quiet':
+        args.quiet = true;
+        break;
+      case '--tick-rate': {
+        const next = Number(argv[i + 1]);
+        if (!Number.isFinite(next) || next <= 0) {
+          throw new Error('--tick-rate requires a positive number');
+        }
+        args.tickRate = next;
+        i += 1;
+        break;
+      }
+      case '--log-interval': {
+        const next = Number(argv[i + 1]);
+        if (!Number.isFinite(next) || next <= 0) {
+          throw new Error('--log-interval requires a positive number of seconds');
+        }
+        args.logIntervalSeconds = next;
+        i += 1;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return args;
+}
+
+function printSummary(summary) {
+  console.log('--- Simulation Summary ---');
+  console.log(`Ticks executed: ${summary.ticks}`);
+  console.log(`Final GET: ${formatGET(summary.finalGetSeconds)}`);
+  console.log('Event counts:', summary.events.counts);
+  if (summary.events.upcoming.length > 0) {
+    console.log('Upcoming events:');
+    for (const event of summary.events.upcoming) {
+      console.log(`  • ${event.id} (${event.phase}) — ${event.status} at ${event.opensAt}`);
+    }
+  }
+  console.log('Resource snapshot:', summary.resources);
+}
+
+main().catch((error) => {
+  console.error('Simulation failed:', error);
+  process.exitCode = 1;
+});

--- a/js/src/logging/missionLogger.js
+++ b/js/src/logging/missionLogger.js
@@ -1,0 +1,33 @@
+import { formatGET } from '../utils/time.js';
+
+export class MissionLogger {
+  constructor({ silent = false } = {}) {
+    this.silent = silent;
+    this.entries = [];
+  }
+
+  log(getSeconds, message, context = {}) {
+    const entry = {
+      getSeconds,
+      message,
+      context,
+    };
+    this.entries.push(entry);
+
+    if (!this.silent) {
+      const prefix = `[GET ${formatGET(getSeconds)}]`;
+      if (context && Object.keys(context).length > 0) {
+        console.log(`${prefix} ${message}`, context);
+      } else {
+        console.log(`${prefix} ${message}`);
+      }
+    }
+  }
+
+  getEntries(filterFn = null) {
+    if (typeof filterFn !== 'function') {
+      return [...this.entries];
+    }
+    return this.entries.filter(filterFn);
+  }
+}

--- a/js/src/sim/eventScheduler.js
+++ b/js/src/sim/eventScheduler.js
@@ -1,0 +1,186 @@
+import { formatGET } from '../utils/time.js';
+
+const STATUS = {
+  PENDING: 'pending',
+  ARMED: 'armed',
+  ACTIVE: 'active',
+  COMPLETE: 'complete',
+  FAILED: 'failed',
+};
+
+export class EventScheduler {
+  constructor(events, autopilotMap, resourceSystem, logger, options = {}) {
+    this.logger = logger;
+    this.resourceSystem = resourceSystem;
+    this.options = options;
+    this.events = events.map((event) => this.prepareEvent(event, autopilotMap));
+    this.eventMap = new Map(this.events.map((event) => [event.id, event]));
+  }
+
+  prepareEvent(event, autopilotMap) {
+    const autopilotId = event.autopilotId ?? event.autopilot_script ?? event.autopilot_script_id ?? null;
+    const autopilot = autopilotId ? autopilotMap.get(autopilotId) ?? null : null;
+    const windowSeconds = Math.max(0, (event.getCloseSeconds ?? 0) - (event.getOpenSeconds ?? 0));
+    let manualDuration = 120;
+    if (windowSeconds > 0) {
+      const halfWindow = windowSeconds * 0.5;
+      const safeWindow = Math.max(5, windowSeconds - 1);
+      manualDuration = Math.max(5, Math.min(halfWindow, safeWindow, 600));
+    }
+
+    return {
+      ...event,
+      autopilotId,
+      autopilot,
+      status: STATUS.PENDING,
+      activationTimeSeconds: null,
+      completionTimeSeconds: null,
+      expectedDurationSeconds: autopilot?.durationSeconds ?? manualDuration,
+    };
+  }
+
+  update(currentGetSeconds, dtSeconds) {
+    for (const event of this.events) {
+      switch (event.status) {
+        case STATUS.PENDING:
+          this.maybeArm(event, currentGetSeconds);
+          break;
+        case STATUS.ARMED:
+          this.maybeActivate(event, currentGetSeconds);
+          this.maybeFail(event, currentGetSeconds, 'Window expired before activation');
+          break;
+        case STATUS.ACTIVE:
+          this.maybeComplete(event, currentGetSeconds);
+          this.maybeFail(event, currentGetSeconds, 'Window expired during execution');
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  maybeArm(event, currentGetSeconds) {
+    if (event.getOpenSeconds == null) {
+      return;
+    }
+
+    if (currentGetSeconds < event.getOpenSeconds) {
+      return;
+    }
+
+    if (!this.arePrerequisitesComplete(event)) {
+      return;
+    }
+
+    event.status = STATUS.ARMED;
+    this.logger.log(currentGetSeconds, `Event ${event.id} armed`, {
+      phase: event.phase,
+      window: `${formatGET(event.getOpenSeconds)} → ${formatGET(event.getCloseSeconds)}`,
+    });
+  }
+
+  maybeActivate(event, currentGetSeconds) {
+    if (event.status !== STATUS.ARMED) {
+      return;
+    }
+
+    if (currentGetSeconds < (event.getOpenSeconds ?? 0)) {
+      return;
+    }
+
+    event.status = STATUS.ACTIVE;
+    event.activationTimeSeconds = currentGetSeconds;
+    this.logger.log(currentGetSeconds, `Event ${event.id} active`, {
+      autopilot: event.autopilotId,
+      checklist: event.checklistId,
+      expectedDurationSeconds: event.expectedDurationSeconds,
+    });
+  }
+
+  maybeComplete(event, currentGetSeconds) {
+    if (event.status !== STATUS.ACTIVE) {
+      return;
+    }
+
+    const elapsed = currentGetSeconds - (event.activationTimeSeconds ?? currentGetSeconds);
+    if (elapsed < event.expectedDurationSeconds) {
+      return;
+    }
+
+    event.status = STATUS.COMPLETE;
+    event.completionTimeSeconds = currentGetSeconds;
+    this.logger.log(currentGetSeconds, `Event ${event.id} complete`, {
+      phase: event.phase,
+    });
+    this.resourceSystem.applyEffect(event.successEffects, {
+      getSeconds: currentGetSeconds,
+      source: event.id,
+      type: 'success',
+    });
+  }
+
+  maybeFail(event, currentGetSeconds, reason) {
+    if (event.status === STATUS.COMPLETE || event.status === STATUS.FAILED) {
+      return;
+    }
+
+    if (event.getCloseSeconds == null) {
+      return;
+    }
+
+    if (currentGetSeconds <= event.getCloseSeconds) {
+      return;
+    }
+
+    event.status = STATUS.FAILED;
+    this.logger.log(currentGetSeconds, `Event ${event.id} failed — ${reason}`, {
+      phase: event.phase,
+    });
+    this.resourceSystem.applyEffect(event.failureEffects, {
+      getSeconds: currentGetSeconds,
+      source: event.id,
+      type: 'failure',
+    });
+  }
+
+  arePrerequisitesComplete(event) {
+    if (!event.prerequisites || event.prerequisites.length === 0) {
+      return true;
+    }
+
+    for (const prereqId of event.prerequisites) {
+      const prereq = this.eventMap.get(prereqId);
+      if (!prereq || prereq.status !== STATUS.COMPLETE) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  stats() {
+    const counts = {
+      [STATUS.PENDING]: 0,
+      [STATUS.ARMED]: 0,
+      [STATUS.ACTIVE]: 0,
+      [STATUS.COMPLETE]: 0,
+      [STATUS.FAILED]: 0,
+    };
+
+    for (const event of this.events) {
+      counts[event.status] += 1;
+    }
+
+    const upcoming = this.events
+      .filter((event) => event.status === STATUS.PENDING || event.status === STATUS.ARMED)
+      .sort((a, b) => (a.getOpenSeconds ?? Infinity) - (b.getOpenSeconds ?? Infinity))
+      .slice(0, 5)
+      .map((event) => ({
+        id: event.id,
+        phase: event.phase,
+        status: event.status,
+        opensAt: formatGET(event.getOpenSeconds ?? 0),
+      }));
+
+    return { counts, upcoming };
+  }
+}

--- a/js/src/sim/resourceSystem.js
+++ b/js/src/sim/resourceSystem.js
@@ -1,0 +1,110 @@
+const DEFAULT_STATE = {
+  power_margin_pct: 100,
+  cryo_boiloff_rate_pct_per_hr: 1.0,
+  thermal_balance_state: 'UNINITIALIZED',
+  ptc_active: false,
+  delta_v_margin_mps: 0,
+};
+
+const DEFAULT_OPTIONS = {
+  logIntervalSeconds: 3600,
+};
+
+const DRIFT_RATES = {
+  powerPerSecond: 0.8 / 3600, // % per second when PTC is off
+  cryoPerSecond: 0.02 / 3600, // % per second when PTC is off
+};
+
+const RECOVERY_RATES = {
+  powerPerSecond: 0.4 / 3600,
+  cryoPerSecond: 0.015 / 3600,
+};
+
+export class ResourceSystem {
+  constructor(logger, options = {}) {
+    this.logger = logger;
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.state = { ...DEFAULT_STATE, ...(options.initialState ?? {}) };
+    this.failures = new Set();
+    this._logCountdown = this.options.logIntervalSeconds;
+  }
+
+  applyEffect(effect, { getSeconds, source, type }) {
+    if (!effect || Object.keys(effect).length === 0) {
+      return;
+    }
+
+    const applied = {};
+
+    for (const [key, value] of Object.entries(effect)) {
+      if (key === 'failure_id') {
+        if (value) {
+          this.failures.add(value);
+          applied.failure_id = value;
+        }
+        continue;
+      }
+
+      if (typeof value === 'number') {
+        const previous = typeof this.state[key] === 'number' ? this.state[key] : 0;
+        this.state[key] = previous + value;
+        applied[key] = this.state[key];
+      } else {
+        this.state[key] = value;
+        applied[key] = value;
+      }
+    }
+
+    if (Object.keys(applied).length > 0) {
+      this.logger.log(getSeconds, `${type === 'failure' ? 'Failure' : 'Resource'} update from ${source}`, {
+        type,
+        source,
+        applied,
+      });
+    }
+  }
+
+  update(dtSeconds, getSeconds) {
+    const stable = this.isPtcStable();
+
+    if (!stable) {
+      this.state.power_margin_pct = Math.max(
+        0,
+        this.state.power_margin_pct - (DRIFT_RATES.powerPerSecond * dtSeconds),
+      );
+      this.state.cryo_boiloff_rate_pct_per_hr = Math.min(
+        5,
+        this.state.cryo_boiloff_rate_pct_per_hr + (DRIFT_RATES.cryoPerSecond * dtSeconds),
+      );
+    } else {
+      this.state.power_margin_pct = Math.min(
+        100,
+        this.state.power_margin_pct + (RECOVERY_RATES.powerPerSecond * dtSeconds),
+      );
+      this.state.cryo_boiloff_rate_pct_per_hr = Math.max(
+        0.5,
+        this.state.cryo_boiloff_rate_pct_per_hr - (RECOVERY_RATES.cryoPerSecond * dtSeconds),
+      );
+    }
+
+    this._logCountdown -= dtSeconds;
+    if (this._logCountdown <= 0) {
+      this.logger.log(getSeconds, 'Resource snapshot', {
+        snapshot: this.snapshot(),
+      });
+      this._logCountdown = this.options.logIntervalSeconds;
+    }
+  }
+
+  snapshot() {
+    return {
+      ...this.state,
+      failures: Array.from(this.failures.values()),
+    };
+  }
+
+  isPtcStable() {
+    const state = this.state.thermal_balance_state ?? '';
+    return state === 'PTC_STABLE' || state === 'PTC_TUNED';
+  }
+}

--- a/js/src/sim/simulation.js
+++ b/js/src/sim/simulation.js
@@ -1,0 +1,42 @@
+import { formatGET } from '../utils/time.js';
+import { SimulationClock } from './simulationClock.js';
+
+export class Simulation {
+  constructor({ scheduler, resourceSystem, logger, tickRate = 20 }) {
+    this.scheduler = scheduler;
+    this.resourceSystem = resourceSystem;
+    this.logger = logger;
+    this.clock = new SimulationClock({ tickRate });
+    this.tickRate = tickRate;
+  }
+
+  run({ untilGetSeconds }) {
+    const dtSeconds = 1 / this.tickRate;
+    let ticks = 0;
+
+    while (this.clock.getCurrent() < untilGetSeconds) {
+      const currentGet = this.clock.getCurrent();
+      this.scheduler.update(currentGet, dtSeconds);
+      this.resourceSystem.update(dtSeconds, currentGet);
+      this.clock.advance();
+      ticks += 1;
+    }
+
+    const stats = this.scheduler.stats();
+    const finalState = this.resourceSystem.snapshot();
+
+    this.logger.log(this.clock.getCurrent(), `Simulation halt at GET ${formatGET(this.clock.getCurrent())}`, {
+      ticks,
+      events: stats.counts,
+      upcoming: stats.upcoming,
+      resources: finalState,
+    });
+
+    return {
+      ticks,
+      finalGetSeconds: this.clock.getCurrent(),
+      events: stats,
+      resources: finalState,
+    };
+  }
+}

--- a/js/src/sim/simulationClock.js
+++ b/js/src/sim/simulationClock.js
@@ -1,0 +1,16 @@
+export class SimulationClock {
+  constructor({ startGetSeconds = 0, tickRate = 20 } = {}) {
+    this.currentGetSeconds = startGetSeconds;
+    this.tickRate = tickRate;
+    this.dtSeconds = 1 / tickRate;
+  }
+
+  advance() {
+    this.currentGetSeconds += this.dtSeconds;
+    return this.currentGetSeconds;
+  }
+
+  getCurrent() {
+    return this.currentGetSeconds;
+  }
+}

--- a/js/src/utils/csv.js
+++ b/js/src/utils/csv.js
@@ -1,0 +1,89 @@
+export function parseCsv(content) {
+  const normalized = normalizeNewlines(content);
+  const rows = [];
+  let field = '';
+  let row = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < normalized.length; i += 1) {
+    const char = normalized[i];
+
+    if (inQuotes) {
+      if (char === '\\') {
+        const nextChar = normalized[i + 1];
+        if (nextChar === '"') {
+          field += '"';
+          i += 1;
+          continue;
+        }
+      }
+
+      if (char === '"') {
+        const nextChar = normalized[i + 1];
+        if (nextChar === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    if (char === ',') {
+      row.push(field);
+      field = '';
+      continue;
+    }
+
+    if (char === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+
+    field += char;
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const headers = rows[0].map((header) => header.replace(/^\ufeff/, '').trim());
+  const records = [];
+
+  for (let i = 1; i < rows.length; i += 1) {
+    const currentRow = rows[i];
+    if (!currentRow || currentRow.length === 0 || currentRow.every((value) => value.trim().length === 0)) {
+      continue;
+    }
+
+    const record = {};
+    for (let j = 0; j < headers.length; j += 1) {
+      const header = headers[j];
+      const value = currentRow[j] ?? '';
+      record[header] = value.trim();
+    }
+    records.push(record);
+  }
+
+  return records;
+}
+
+function normalizeNewlines(value) {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}

--- a/js/src/utils/time.js
+++ b/js/src/utils/time.js
@@ -1,0 +1,37 @@
+const GET_PATTERN = /^(\d{3}):(\d{2}):(\d{2})$/;
+
+export function parseGET(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  const match = GET_PATTERN.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const [, h, m, s] = match;
+  const hours = Number.parseInt(h, 10);
+  const minutes = Number.parseInt(m, 10);
+  const seconds = Number.parseInt(s, 10);
+  if (Number.isNaN(hours) || Number.isNaN(minutes) || Number.isNaN(seconds)) {
+    return null;
+  }
+  return (hours * 3600) + (minutes * 60) + seconds;
+}
+
+export function formatGET(totalSeconds) {
+  const seconds = Math.max(0, Math.floor(totalSeconds ?? 0));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainder = seconds % 60;
+  return `${hours.toString().padStart(3, '0')}:${minutes.toString().padStart(2, '0')}:${remainder
+    .toString()
+    .padStart(2, '0')}`;
+}
+
+export function secondsBetween(a, b) {
+  if (a == null || b == null) {
+    return null;
+  }
+  return Math.abs(a - b);
+}


### PR DESCRIPTION
## Summary
- add a Node-based simulation harness in `js/src/` that loads the M0 datasets, runs the deterministic scheduler/resource loop, and logs GET-stamped events
- implement custom CSV parsing, mission data loading, event scheduling, and resource tracking modules that match the M1 planning notes
- refresh repository and milestone documentation to highlight the new CLI prototype and outline the remaining M1 gaps

## Testing
- npm start -- --until 005:30:00
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca03b5a03483238e4fee5fc3115717