### PR TITLE
Document late-stage milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Milestone M2 planning notes outline guidance, RCS, and docking system requirements in [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) to steer upcoming implementation work.
 - Milestone M3 UI, HUD, and audio telemetry planning in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) defines presentation-layer architecture, cue taxonomy, and accessibility handoff targets for the JS prototype and N64 port.
 - Milestone M4 N64 port plan in [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) maps the libdragon architecture, rendering/audio budgets, input scheme, and asset pipeline for the hardware build.
+- Milestone M5 content integration roadmap in [`docs/milestones/M5_CONTENT_PASS.md`](docs/milestones/M5_CONTENT_PASS.md) itemizes the remaining dataset ingestion work, contingency branches, and ingestion tooling required for the full mission graph.
+- Milestone M6 fidelity pass outline in [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) defines calibration targets for timelines, propulsion, resources, and communications against Apollo 11 telemetry.
+- Milestone M7 stability plan in [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) details soak-testing strategy, fault injection coverage, and automation expectations for release readiness.
 - Manual action recorder in [`js/src/logging/manualActionRecorder.js`](js/src/logging/manualActionRecorder.js) can capture auto-advanced checklist steps and export them via the CLI `--record-manual-script` flag for deterministic manual-vs-auto parity runs.
 
 ## Immediate Priorities
@@ -32,6 +35,9 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) – Guidance execution, RCS modelling, and docking gameplay plan.
 - [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) – UI, HUD, audio telemetry, and accessibility planning for the prototype and N64 targets.
 - [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) – N64 port architecture, performance validation plan, and Controller Pak integration roadmap.
+- [`docs/milestones/M5_CONTENT_PASS.md`](docs/milestones/M5_CONTENT_PASS.md) – Complete mission dataset integration, contingency coverage, and ingest tooling roadmap.
+- [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) – Calibration plan for timelines, resources, and communications fidelity.
+- [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) – Stability, fault injection, soak testing, and automation strategy.
 - [`docs/data/README.md`](docs/data/README.md) – Normalized mission datasets produced during Milestone M0 (currently covering launch through splashdown).
 - [`docs/data/VALIDATION_CHECKS.md`](docs/data/VALIDATION_CHECKS.md) – Automated dataset sweep coverage and guidance for extending the validation CLI.
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -96,10 +96,10 @@ Supporting details for each milestone live in [`docs/milestones/`](milestones).
 2. **M1:** Core engine (loop, scheduler, resources, PTC) documented in [`milestones/M1_CORE_SYSTEMS.md`](milestones/M1_CORE_SYSTEMS.md).
 3. **M2:** Guidance and RCS (burn execution, docking minigame) documented in [`milestones/M2_GUIDANCE_RCS.md`](milestones/M2_GUIDANCE_RCS.md).
 4. **M3:** UI/HUD and audio presentation planning captured in [`milestones/M3_UI_AUDIO.md`](milestones/M3_UI_AUDIO.md).
-5. **M4:** N64 port and performance tuning.
-6. **M5:** Content pass for full Apollo 11 mission graph.
-7. **M6:** Fidelity pass aligning to GET anchors.
-8. **M7:** Stability, fault injection, and long-run soak tests.
+5. **M4:** N64 port and performance tuning documented in [`milestones/M4_N64_PORT.md`](milestones/M4_N64_PORT.md).
+6. **M5:** Content pass for the full Apollo 11 mission graph detailed in [`milestones/M5_CONTENT_PASS.md`](milestones/M5_CONTENT_PASS.md).
+7. **M6:** Fidelity pass aligning to GET anchors covered in [`milestones/M6_FIDELITY_PASS.md`](milestones/M6_FIDELITY_PASS.md).
+8. **M7:** Stability, fault injection, and long-run soak tests defined in [`milestones/M7_STABILITY_FAULTS.md`](milestones/M7_STABILITY_FAULTS.md).
 
 ## 12. Stage Consequence Table (Excerpt)
 

--- a/docs/milestones/M5_CONTENT_PASS.md
+++ b/docs/milestones/M5_CONTENT_PASS.md
@@ -1,0 +1,47 @@
+# Milestone M5 — Full Mission Content Pass
+
+Milestone M5 transforms the simulator from a representative slice of the Apollo 11 mission into a complete multi-day experience. The focus shifts from new engine features to curating the remaining mission procedures, PADs, autopilot references, and failure hooks so every checklist item and mission beat is represented in the structured datasets.
+
+## Objectives
+- Close all outstanding gaps in the mission datasets so events, checklists, PADs, autopilots, failures, and consumables cover GET 000:00:00 through splashdown without placeholders.
+- Produce mission graph annotations for optional branches (aborts, contingency MCCs, alternate checklist flows) with clear prerequisites and recovery hooks.
+- Verify that every dataset record includes provenance metadata back to the source document or transcript segment.
+- Deliver ingest notebooks or scripts that regenerate the CSV/JSON packs and validate them with the automated sweep from Milestone M0.
+
+## Mission Content Backlog
+
+The following content areas require focused extraction and cross-checking before M5 is complete:
+
+### Surface Operations
+- **EVA-2 timeline:** Capture the second EVA traverses, sample collection, ALSEP deployment, and closeout procedures. Each checklist entry should reference Flight Journal Day 6 transcripts and Flight Plan Section 7 updates.
+- **Surface anomalies & cues:** Add failure hooks for suit delta-P excursions, biomedical telemetry alerts, and timeline slips when geology tasks run long. Map their recovery actions to mission rules (e.g., skip second traverse leg, re-enter early).
+- **Crew rest periods:** Record GET anchors for post-EVA sleep cycles, ensuring the scheduler blocks conflicting events and updates consumable trends accordingly.
+
+### Transearth Coast & Entry
+- **DSN support analytics:** Expand the transearth communications entries with signal strength trends, handover timing between stations, and resource implications when windows slip.
+- **MCC-5 refinement:** Incorporate post-flight dispersion analyses, burn trim options, and the associated failure/recovery steps for missed TIG or underburn cases.
+- **Entry corridor management:** Detail the lift vector steering callouts, backup PAD references, and failure cascades for corridor violations or drogue deployment delays.
+
+### Contingency & Optional Branches
+- **Abort ladders:** Document key abort opportunities (e.g., TLI+X, LOI no-go, late PDI wave-offs) with their alternate PAD requirements, checklists, and resource deltas.
+- **Pad uplink retries:** Model DSN-driven retry cadence for PAD transmissions, including communications blackout propagation into the scheduler and failure taxonomy.
+- **Crew-initiated deviations:** Provide explicit manual action hooks for common deviations (e.g., extra P52 alignments, additional consumables surveys) with documented resource effects.
+
+## Data Integration Workflow
+1. **Source synthesis:** Continue leveraging the canonical spreadsheets or note-taking environment to collate GET-tagged procedures. Track source references alongside each row.
+2. **Notebook automation:** Create Python notebooks under `scripts/ingest/` (or equivalent) that transform annotated sheets into normalized CSV/JSON files. Each notebook should include embedded validation cells that call the shared GET/parsing helpers.
+3. **Schema extensions:** When new columns are required (e.g., `abort_branch`, `audio_cue` placeholders, DSN metrics), document them in `docs/data/README.md` and extend the validator in `js/src/tools/validateMissionData.js` so regressions are caught immediately.
+4. **Iterative validation:** Run the validator after every major data injection. Capture summary stats (event counts per phase, checklist coverage) to confirm the mission graph stays balanced.
+5. **Provenance log updates:** Expand `docs/data/provenance.md` with row ranges covering the new entries and cite the exact Flight Plan pages, Mission Operations Report sections, or Flight Journal timestamps used.
+
+## Tooling & Collaboration Notes
+- The ingest notebooks/scripts should support partial regeneration so teams can iterate on a subset (e.g., EVA-2 checklists) without clobbering other packs.
+- Document export settings (CSV delimiter, GET formatting, JSON indent rules) so contributors using different tooling produce consistent results.
+- Annotate outstanding questions (e.g., ambiguous transcript timing) in `provenance.md` or companion notes to flag research tasks for future updates.
+- Coordinate with the HUD/audio planning (Milestone M3) to ensure newly introduced event metadata anticipates upcoming UI cues.
+
+## Validation & Acceptance Criteria
+- All mission phases, including optional/contingency paths, exist in the datasets with no placeholder text (`TBD`, `TODO`).
+- The ingestion notebooks/scripts run end-to-end to regenerate the packs and finish with a clean `npm run validate:data` pass.
+- Sample mission queries—"Which events block LOI if MCC-4 is skipped?", "List all power-related failures during EVA-2"—can be answered directly from the datasets without re-opening the source documents.
+- The README and project plan reference the completed datasets and direct contributors to the ingest tooling for reproducible updates.

--- a/docs/milestones/M6_FIDELITY_PASS.md
+++ b/docs/milestones/M6_FIDELITY_PASS.md
@@ -1,0 +1,39 @@
+# Milestone M6 — Historical Fidelity & Calibration Pass
+
+Milestone M6 focuses on validating the simulator against Apollo 11 historical data. After the mission graph is complete, this pass tightens every numeric assumption—timelines, Δv, propellant usage, communications windows, and environmental models—so the experience aligns with documented tolerances.
+
+## Objectives
+- Align major GET anchors (TLI, LOI, PDI, landing, TEI, entry interface, splashdown) to within documented tolerances when the simulator is flown nominally.
+- Calibrate propulsion, thermal, and power models against Mission Operations Report data and post-flight analysis.
+- Validate communications coverage, PAD timing, and DSN shift rotations to mirror the historical mission.
+- Capture calibration notes and tunable parameters so deviations are explicit and reproducible.
+
+## Timeline & Trajectory Alignment
+- **Anchor verification:** Cross-check event activations against Flight Journal transcripts and the official Flight Plan timeline. Produce a table highlighting expected vs. simulated GET for all major milestones.
+- **Autopilot retiming:** Compare burn profiles (TLI, MCC series, LOI, DOI, PDI, LM ascent, TEI, MCC-5, entry) against documented TIG, duration, and achieved Δv. Adjust script step durations, throttle ramps, and ullage timing until the delta is within ±2 seconds and ±1.5 m/s.
+- **Coast phasing:** Validate passive thermal control cadence, navigation realignments, and rendezvous phasing burns to ensure the mission clock stays synchronized through long coast segments.
+- **Event slack documentation:** Record any intentional slack (e.g., checklist buffering, autopilot warm-ups) needed to maintain timeline accuracy so the HUD can surface it to the player.
+
+## Resource & Environmental Calibration
+- **Propellant tracking:** Use Mission Operations Report propellant consumption tables to tune mass-flow coefficients, RCS impulse budgets, and residual margins. Add assertions to the resource system to flag when runs deviate by more than ±3% from the historical trend.
+- **Power systems:** Model fuel cell loads, cryogenic boiloff, and battery usage against documented telemetry. Introduce configurable load profiles for EVA support equipment, comms high-gain modes, and PTC off-nominal cases.
+- **Thermal modelling:** Validate PTC effectiveness and thermal drift penalties with historical cryo pressure trends. Ensure failure cascades (e.g., prolonged PTC outage) match documented risk envelopes.
+- **Life support:** Align oxygen, water, and LiOH consumption with EVA timelines and cabin repress events. Capture adjustments required when EVA timing slips during scenario testing.
+
+## Communications & PAD Delivery
+- **DSN coverage:** Overlay simulated antenna handovers with DSN schedule tables. Confirm no planned PAD or critical event occurs outside an available window when flown nominally.
+- **PAD timing:** Validate uplink and execution times for guidance updates, ensuring the scheduler enforces the same guard bands used historically.
+- **Voice & telemetry cues:** Cross-reference logged audio cue timestamps (from M3 planning) with transcript segments to guarantee the simulator honours mission cadence.
+
+## Tooling & Workflow Enhancements
+- Build calibration notebooks that ingest simulation logs, compute error metrics, and visualize deviations against historical baselines. Store them under `scripts/calibration/` (or similar) with clear execution instructions.
+- Extend `npm run validate:data` or companion scripts to assert known calibration thresholds (e.g., `landing_get_error < 5s`).
+- Introduce configuration files capturing tunable constants (mass-flow multipliers, controller gains, PTC coefficients) and document their provenance.
+- Capture calibration runs as deterministic log archives so future regressions can be diffed without replaying the entire mission manually.
+
+## Validation & Acceptance Criteria
+- Nominal simulation runs match the historical timeline within agreed tolerances for all milestone anchors.
+- Resource telemetry (propellant, power, thermal, life support) stays within ±3% of documented values over the full mission, with deviations explained and documented.
+- Communications windows never miss scheduled PAD deliveries in nominal runs; deliberate deviations trigger the correct failure cascades.
+- Calibration notebooks produce summary reports used during review, and any parameter tweaks are checked into version control with citations.
+- README and milestone documentation summarize the calibration status and direct contributors to the notebooks and configuration files for reproducible tuning.

--- a/docs/milestones/M7_STABILITY_FAULTS.md
+++ b/docs/milestones/M7_STABILITY_FAULTS.md
@@ -1,0 +1,42 @@
+# Milestone M7 — Stability, Fault Injection, and Soak Testing
+
+Milestone M7 hardens the simulator for release-quality reliability. With mission content and calibration in place, the focus shifts to proving deterministic behavior across multi-day runs, exercising the failure taxonomy, and ensuring saves/logs remain intact under stress.
+
+## Objectives
+- Execute long-duration simulations (≥195 GET hours) without crashes, runaway resource errors, or desynchronization.
+- Validate that every failure hook can be triggered intentionally and recovers or terminates the mission according to plan.
+- Establish automated soak suites that replay nominal, off-nominal, and fault-injected scenarios deterministically.
+- Confirm save/load integrity, log completeness, and regression tooling resilience.
+
+## Test Matrix & Soak Strategy
+- **Nominal endurance runs:** Weekly full-mission simulations with autopilot/manual parity scripts, verifying identical logs and resource traces.
+- **Stress permutations:** Time-compression sweeps (2×, 4×, 8×, 16×, 60×), manual override heavy runs (frequent manual checklist acknowledgements, manual burns), and mixed autopilot/manual control sequences.
+- **Edge-case slices:** Focused runs for high-risk segments (TLI to MCC-2, LOI through landing, LM ascent rendezvous, transearth reentry) with repeated seeds to catch race conditions.
+- **Platform variability:** Document performance and determinism checks across Node.js versions for the JS build and hardware/emu combinations for the N64 port once available.
+
+## Fault Injection Coverage
+- **Scheduler faults:** Delay or skip events, inject stale prerequisites, and confirm cascading penalties and recovery events activate as documented.
+- **Autopilot anomalies:** Force ullage failures, throttle mis-tracks, or cutoffs. Validate Δv deltas and failure classifications align with mission data.
+- **Resource excursions:** Simulate cryo leaks, fuel cell degradation, RCS jet failures, or excessive PTC drift. Ensure alerts, HUD cues, and remedial checklists engage.
+- **Communications outages:** Block PAD deliveries, degrade DSN windows, and introduce noisy telemetry to confirm fallback procedures and scoring implications.
+- **Save/load resilience:** Serialize mid-fault states, reload, and confirm the simulation resumes with consistent scheduler/resource state.
+
+Each injected fault should log the trigger, affected systems, and observed recovery steps with GET stamps for auditability.
+
+## Observability & Tooling
+- **Metrics capture:** Extend mission logs with structured fields for frame time, scheduler queue depth, autopilot command backlog, and resource guard-band violations.
+- **Health dashboards:** Provide scripts that aggregate soak test logs into summaries (mean FPS, maximum resource deviation, failure counts) to spot regressions quickly.
+- **Alerting:** Define thresholds for soak failures (e.g., simulation loop latency >50 ms, parity drift >1e-6) and integrate them with CI notifications or dashboards.
+- **Determinism audits:** Automate byte-level comparisons of log archives between runs with identical seeds. Document accepted tolerances for floating-point drift, if any.
+
+## Automation & Infrastructure
+- Stand up nightly CI jobs that execute representative soak scenarios and publish artifacts (logs, parity reports, screenshots once HUD/UI exist).
+- Schedule manual deep-dive sessions for newly added faults or mission branches to confirm coverage.
+- Maintain a catalogue of known issues with reproduction steps, affected datasets, and mitigation strategies for transparency.
+- Coordinate with localization/accessibility stakeholders to ensure UI/audio additions from M3 remain stable under long runs and recover gracefully from restarts.
+
+## Validation & Acceptance Criteria
+- All planned soak scenarios complete without unhandled exceptions, memory leaks, or deterministic drift outside documented tolerances.
+- Every failure hook has a reproducible test case, log snippet, and recovery status documented in `docs/data/provenance.md` or a dedicated fault notebook.
+- Save files generated at key GET checkpoints reload successfully and resume autopilot/manual sequences without divergence.
+- CI or automation dashboards surface pass/fail status for soak suites, and README/milestone documentation points contributors to the workflow for ongoing maintenance.


### PR DESCRIPTION
## Summary
- add milestone planning documents for the content pass, fidelity calibration, and stability soak phases
- update the project plan and repository README to reference the new milestone roadmaps

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca42848cb48323a1d0a691ba9322f4