### PR TITLE
Document ingestion notebook workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - `js/` – Workspace for the JavaScript/Web prototype that will validate the mission model and user experience.
 - `n64/` – Workspace for the libdragon-powered Nintendo 64 port that inherits the proven systems from the web build.
 - `docs/` – Planning and reference material for the project, including the current mission and technology plan.
+- `scripts/ingest/` – Planned notebooks and helper modules that turn annotated research assets into the committed datasets.
 
 ## Current Progress
 - Milestone M0 datasets now cover launch through splashdown, capturing extended Passive Thermal Control maintenance, MCC-1/2/3/4 PAD workflows, LOI-focused navigation realignments, DOI planning, LM separation, powered descent and landing safing, surface EVA-1 prep/egress/traverse/closeout, ascent/docking evaluation, TEI preparation and execution, transearth DSN communications passes, MCC-5 return corrections, entry PAD alignment, service module jettison, and recovery procedures.
@@ -23,6 +24,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Milestone M6 fidelity pass outline in [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) defines calibration targets for timelines, propulsion, resources, and communications against Apollo 11 telemetry.
 - Milestone M7 stability plan in [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) details soak-testing strategy, fault injection coverage, and automation expectations for release readiness.
 - Manual action recorder in [`js/src/logging/manualActionRecorder.js`](js/src/logging/manualActionRecorder.js) can capture auto-advanced checklist steps and export them via the CLI `--record-manual-script` flag for deterministic manual-vs-auto parity runs.
+- Ingestion workflow planning under [`scripts/ingest/`](scripts/ingest/README.md) and [`docs/data/INGESTION_PIPELINE.md`](docs/data/INGESTION_PIPELINE.md) now documents how future dataset updates move from annotated sources into the CSV/JSON packs, including notebook sequencing, validation checkpoints, and automation hooks.
 
 ## Immediate Priorities
 1. Continue Milestone M0 by publishing ingestion notebooks under `scripts/ingest/`, rounding out contingency datasets, and wiring the new EVA/DSN analytics into automated regression notebooks while extending the validation CLI as new schema fields appear.
@@ -42,6 +44,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) – Stability, fault injection, soak testing, and automation strategy.
 - [`docs/data/README.md`](docs/data/README.md) – Normalized mission datasets produced during Milestone M0 (currently covering launch through splashdown).
 - [`docs/data/VALIDATION_CHECKS.md`](docs/data/VALIDATION_CHECKS.md) – Automated dataset sweep coverage and guidance for extending the validation CLI.
+- [`docs/data/INGESTION_PIPELINE.md`](docs/data/INGESTION_PIPELINE.md) – Step-by-step workflow for running the ingestion notebooks, validating outputs, and planning future automation.
 
 ## Contribution Notes
 - Follow the guidelines in [`AGENTS.md`](AGENTS.md) for documentation structure and future implementation phases.

--- a/docs/data/INGESTION_PIPELINE.md
+++ b/docs/data/INGESTION_PIPELINE.md
@@ -1,0 +1,38 @@
+# Mission Data Ingestion Pipeline
+
+This note expands on the Milestone M0 roadmap by detailing how future dataset updates should flow from research annotations into the committed CSV and JSON packs. It pairs with the notebooks planned in `scripts/ingest/` so contributors share a consistent mental model of the tooling.
+
+## Source Preparation Checklist
+
+1. **Annotate primary sources** – Update the working spreadsheets with new GET anchors, checklist deltas, and provenance references. Maintain column naming conventions so the notebooks can parse revisions without manual surgery.
+2. **Record assumptions** – Capture any interpretation decisions directly in the spreadsheet (e.g., clarifying Flight Journal vs. Flight Plan timing discrepancies) and mirror the summary in `docs/data/provenance.md` when exporting.
+3. **Stage raw assets** – Store supporting PDFs, scans, or CSVs in a temporary `_input` staging folder that the notebooks will read. Temporary artifacts should remain uncommitted.
+
+## Notebook Execution Order
+
+The recommended execution order keeps downstream dependencies satisfied:
+
+1. `timeline_extraction.ipynb`
+2. `checklist_builder.ipynb`
+3. `pad_parser.ipynb`
+4. `autopilot_catalog.ipynb`
+5. `failure_taxonomy.ipynb`
+6. `communications_trends.ipynb`
+7. `consumables_budget.ipynb`
+
+Running notebooks in this sequence ensures that event windows, checklists, PADs, autopilot metadata, and failure hooks stay synchronized before communications and consumables analytics recalculate their derivatives.
+
+## Export & Review Protocol
+
+- **Generated outputs** should land in `_build/` while under review. Once validated, copy the refreshed CSV/JSON files into `docs/data/` and update `docs/data/provenance.md` with row ranges and citations.
+- **Diff inspection** is required for each dataset. Confirm that GET windows remain ordered, new prerequisites resolve, and autopilot references still link to existing JSON scripts. When large structural changes appear, add explanatory notes to the pull request summary.
+- **Validation** relies on `npm run validate:data` from the JS workspace. Address warnings immediately so the dataset maintains parity with the simulator expectations documented for Milestones M0 and M1.
+- **Parity checks** should be run via `npm run parity` when manual action scripts or autopilot entries change, verifying manual/autopilot equivalence across the relevant mission segments.
+
+## Future Automation Hooks
+
+- Convert the helper modules shared by the notebooks into a Python package (`ingestlib`) to support command-line batch runs and CI automation.
+- Add smoke tests that re-run the notebooks in `--execute` mode and assert that regenerated CSVs are byte-identical to the committed versions unless an explicit update is requested.
+- Schedule notebook execution in long-running branches to generate regression dashboards (propellant trends, DSN coverage) that can be embedded into milestone reports.
+
+By codifying the ingestion flow, the project can continue expanding the mission datasets without jeopardizing the deterministic behavior that the JS prototype and N64 port rely upon.

--- a/scripts/ingest/README.md
+++ b/scripts/ingest/README.md
@@ -1,0 +1,39 @@
+# Ingestion Notebook Workspace
+
+This directory will collect the reproducible notebooks and helper scripts that convert the annotated Apollo 11 research assets into the normalized CSV and JSON packs used by the simulator. Milestone M0 identifies the raw sources, target schemas, and validation expectations; the goal of this workspace is to translate that guidance into versioned tooling that keeps the dataset trustworthy as it expands (see `docs/milestones/M0_DATA_INGESTION.md`).
+
+## Planned Notebook Set
+
+The ingestion workflow is intentionally modular so new data slices and contingency branches can be onboarded without rewriting earlier steps.
+
+| Notebook | Purpose | Key Outputs |
+| --- | --- | --- |
+| `timeline_extraction.ipynb` | Parse Flight Plan and Flight Journal GET stamps into a canonical minute-by-minute ledger while flagging conflicts for manual review. | Intermediate timeline table (`_build/timeline.parquet`) and a diff report against previously committed exports. |
+| `checklist_builder.ipynb` | Transform checklist annotations into atomic steps with crew roles, expected responses, and citations. | `docs/data/checklists.csv` refresh plus checklist provenance appendix updates. |
+| `pad_parser.ipynb` | Capture PAD cards, normalize parameters, and derive validity windows. | Updated `docs/data/pads.csv` and supplemental JSON describing parameter semantics for downstream validation. |
+| `autopilot_catalog.ipynb` | Convert annotated burn profiles into JSON command sequences, record propulsion metadata, and stitch tolerances into the CSV catalog. | JSON files under `docs/data/autopilots/` and the accompanying `docs/data/autopilots.csv` row updates. |
+| `failure_taxonomy.ipynb` | Aggregate failure callouts from the Flight Journal and MOCR notes into the structured taxonomy. | `docs/data/failures.csv` refresh plus inline links for recovery actions. |
+| `communications_trends.ipynb` | Maintain the Deep Space Network analytics, ensuring GET windows, handovers, and signal strength trends stay synchronized with event data. | `docs/data/communications_trends.json` and summary dashboards for regression review. |
+| `consumables_budget.ipynb` | Track baseline power, propellant, and life support budgets, pulling deltas from Mission Operations Report tables. | `docs/data/consumables.json` revisions and variance plots that feed the validation CLI. |
+
+Notebooks will share helper modules for GET parsing, prerequisite resolution, and provenance logging so they stay aligned with the validator and avoid schema drift.
+
+## Helper Modules
+
+A lightweight Python package (`ingestlib`) will live alongside the notebooks and expose:
+
+- **GET utilities** – conversions between `HHH:MM:SS` strings, floating-minute offsets, and pandas `Timedelta` objects.
+- **Schema guards** – dataclass-backed representations of events, checklists, PADs, autopilots, and failures mirroring the definitions documented for Milestone M0.
+- **Reference resolvers** – helpers that verify prerequisites, autopilot IDs, checklist links, and failure references before export.
+- **Provenance logging** – wrappers that write row ranges and source citations into `docs/data/provenance.md` with consistent formatting.
+
+The package will be imported by each notebook to minimize duplicated logic and make it easier to transition the ingestion flow into headless scripts later.
+
+## Execution Workflow
+
+1. **Annotate Sources** – Update the research spreadsheets/OCR documents, capture new GET anchors, and mark provenance references.
+2. **Run Notebooks** – Execute the relevant notebook(s) in order, supplying the annotated sources and committing regenerated CSV/JSON outputs.
+3. **Validate** – Execute `npm run validate:data` from the JS workspace to run the automated sweep before committing changes (see `docs/data/VALIDATION_CHECKS.md`).
+4. **Review Diffs** – Inspect git diffs for large structural changes, confirm provenance updates, and run parity checks where applicable.
+
+Future automation can convert the notebooks into CLI tasks, but keeping the notebooks checked in first ensures the ingestion logic remains auditable and editable as the datasets evolve.


### PR DESCRIPTION
## Summary
- add an ingestion workspace README that outlines the notebook plan, helper modules, and execution workflow
- document the end-to-end mission data ingestion pipeline alongside the existing datasets
- update the project README with the new workspace and documentation references

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cadf1226348323850f738845d5a348