### PR TITLE
Add ingestlib helper package for mission data notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Milestone M7 stability plan in [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) details soak-testing strategy, fault injection coverage, and automation expectations for release readiness.
 - Manual action recorder in [`js/src/logging/manualActionRecorder.js`](js/src/logging/manualActionRecorder.js) can capture auto-advanced checklist steps and export them via the CLI `--record-manual-script` flag for deterministic manual-vs-auto parity runs.
 - Ingestion workflow planning under [`scripts/ingest/`](scripts/ingest/README.md) and [`docs/data/INGESTION_PIPELINE.md`](docs/data/INGESTION_PIPELINE.md) now documents how future dataset updates move from annotated sources into the CSV/JSON packs, including notebook sequencing, validation checkpoints, and automation hooks.
+- Shared Python helpers under [`scripts/ingest/ingestlib/`](scripts/ingest/ingestlib) expose GET utilities, typed dataset loaders, validation routines, and provenance table builders so notebooks and future automation reuse a single source of truth.
 
 ## Immediate Priorities
 1. Continue Milestone M0 by publishing ingestion notebooks under `scripts/ingest/`, rounding out contingency datasets, and wiring the new EVA/DSN analytics into automated regression notebooks while extending the validation CLI as new schema fields appear.

--- a/docs/data/INGESTION_PIPELINE.md
+++ b/docs/data/INGESTION_PIPELINE.md
@@ -23,6 +23,22 @@ The recommended execution order keeps downstream dependencies satisfied:
 
 Running notebooks in this sequence ensures that event windows, checklists, PADs, autopilot metadata, and failure hooks stay synchronized before communications and consumables analytics recalculate their derivatives.
 
+## Shared Notebook Helpers
+
+The helper package under [`scripts/ingest/ingestlib/`](../../scripts/ingest/ingestlib) centralizes GET conversions, typed record objects, dataset loaders, validation routines, and provenance table builders. Import these modules directly from notebooks so the ingestion flow stays aligned with the JS validator and future automation.
+
+```python
+# Ensure PYTHONPATH includes scripts/ingest when running this snippet outside the notebook environment.
+from pathlib import Path
+from ingestlib import load_mission_data, validate_mission_data
+
+mission = load_mission_data(Path('..') / '..' / 'docs' / 'data')
+issues = validate_mission_data(mission)
+print(f"Validation issues: {len(issues)}")
+```
+
+Use `ProvenanceBuilder` from the same package to append table rows to `docs/data/provenance.md` when exporting refreshed CSVs.
+
 ## Export & Review Protocol
 
 - **Generated outputs** should land in `_build/` while under review. Once validated, copy the refreshed CSV/JSON files into `docs/data/` and update `docs/data/provenance.md` with row ranges and citations.
@@ -32,7 +48,7 @@ Running notebooks in this sequence ensures that event windows, checklists, PADs,
 
 ## Future Automation Hooks
 
-- Convert the helper modules shared by the notebooks into a Python package (`ingestlib`) to support command-line batch runs and CI automation.
+- Extend the `ingestlib` helpers with CLI entrypoints so notebook logic can run headlessly in CI or scheduled regression jobs.
 - Add smoke tests that re-run the notebooks in `--execute` mode and assert that regenerated CSVs are byte-identical to the committed versions unless an explicit update is requested.
 - Schedule notebook execution in long-running branches to generate regression dashboards (propellant trends, DSN coverage) that can be embedded into milestone reports.
 

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -10,6 +10,8 @@ This directory contains the structured mission datasets produced during Mileston
 
 Future updates will publish the ingestion notebooks under `scripts/ingest/`, expand contingency branches, and wire the new analytics into regression notebooks as described in the milestone plan.
 
+The shared helper package at [`../scripts/ingest/ingestlib/`](../../scripts/ingest/ingestlib) exposes GET parsers, typed dataset loaders, validation utilities, and provenance builders so notebooks and automation reuse consistent logic.
+
 ## Validation Harness
 
 - Run `cd js && npm run validate:data` to execute the mission dataset sweep implemented in [`../../js/src/tools/validateMissionData.js`](../../js/src/tools/validateMissionData.js).

--- a/scripts/ingest/ingestlib/__init__.py
+++ b/scripts/ingest/ingestlib/__init__.py
@@ -1,0 +1,34 @@
+"""Utility helpers for Apollo 11 mission dataset ingestion notebooks.
+
+This lightweight package exposes the shared helpers referenced in
+``docs/data/INGESTION_PIPELINE.md`` so that notebooks and future
+headless scripts can normalize GET timestamps, parse the committed CSV
+packs, and emit provenance tables without duplicating boilerplate.
+"""
+
+from . import time
+from .loader import load_mission_data
+from .provenance import ProvenanceBuilder
+from .records import (
+    AutopilotRecord,
+    ChecklistEntry,
+    EventRecord,
+    FailureRecord,
+    MissionData,
+    PadRecord,
+)
+from .validation import ValidationIssue, validate_mission_data
+
+__all__ = [
+    "time",
+    "load_mission_data",
+    "ProvenanceBuilder",
+    "AutopilotRecord",
+    "ChecklistEntry",
+    "EventRecord",
+    "FailureRecord",
+    "MissionData",
+    "PadRecord",
+    "ValidationIssue",
+    "validate_mission_data",
+]

--- a/scripts/ingest/ingestlib/loader.py
+++ b/scripts/ingest/ingestlib/loader.py
@@ -1,0 +1,99 @@
+"""File loaders for the committed mission datasets."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .records import (
+    AutopilotRecord,
+    ChecklistEntry,
+    EventRecord,
+    FailureRecord,
+    MissionData,
+    PadRecord,
+)
+_DATA_FILES = {
+    "events": "events.csv",
+    "checklists": "checklists.csv",
+    "autopilots": "autopilots.csv",
+    "pads": "pads.csv",
+    "failures": "failures.csv",
+    "consumables": "consumables.json",
+    "communications": "communications_trends.json",
+    "thrusters": "thrusters.json",
+}
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, escapechar='\\')
+        return [dict(row) for row in reader]
+
+
+def _read_json(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_events(path: Path) -> List[EventRecord]:
+    return [EventRecord.from_row(row) for row in _read_csv(path)]
+
+
+def load_checklists(path: Path) -> List[ChecklistEntry]:
+    return [ChecklistEntry.from_row(row) for row in _read_csv(path)]
+
+
+def load_autopilots(path: Path, data_dir: Path) -> List[AutopilotRecord]:
+    return [AutopilotRecord.from_row(row, data_dir) for row in _read_csv(path)]
+
+
+def load_pads(path: Path) -> List[PadRecord]:
+    return [PadRecord.from_row(row) for row in _read_csv(path)]
+
+
+def load_failures(path: Path) -> List[FailureRecord]:
+    return [FailureRecord.from_row(row) for row in _read_csv(path)]
+
+
+def load_mission_data(data_dir: Path) -> MissionData:
+    base = Path(data_dir).resolve()
+    events = load_events(base / _DATA_FILES["events"])
+    checklists = load_checklists(base / _DATA_FILES["checklists"])
+    autopilots = load_autopilots(base / _DATA_FILES["autopilots"], base)
+    pads = load_pads(base / _DATA_FILES["pads"])
+    failures = load_failures(base / _DATA_FILES["failures"])
+
+    consumables = _read_json(base / _DATA_FILES["consumables"])
+    communications = _read_json(base / _DATA_FILES["communications"])
+    thrusters = _read_json(base / _DATA_FILES["thrusters"])
+
+    return MissionData(
+        events=events,
+        checklists=checklists,
+        autopilots=autopilots,
+        pads=pads,
+        failures=failures,
+        consumables=consumables,
+        communications=communications,
+        thrusters=thrusters,
+    )
+
+
+def available_datasets() -> Iterable[str]:
+    """Return the dataset keys known to the loader."""
+
+    return tuple(_DATA_FILES.keys())
+
+
+__all__ = [
+    "load_events",
+    "load_checklists",
+    "load_autopilots",
+    "load_pads",
+    "load_failures",
+    "load_mission_data",
+    "available_datasets",
+]

--- a/scripts/ingest/ingestlib/provenance.py
+++ b/scripts/ingest/ingestlib/provenance.py
@@ -1,0 +1,60 @@
+"""Helpers for emitting provenance tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .utils import clean_string
+
+
+@dataclass
+class ProvenanceEntry:
+    dataset: str
+    row_range: str
+    source: str
+    notes: Optional[str] = None
+
+
+@dataclass
+class ProvenanceBuilder:
+    """Collect provenance entries and emit Markdown tables."""
+
+    entries: List[ProvenanceEntry] = field(default_factory=list)
+
+    def add(self, dataset: str, row_range: str, source: str, *, notes: Optional[str] = None) -> None:
+        self.entries.append(
+            ProvenanceEntry(
+                dataset=dataset,
+                row_range=row_range,
+                source=source,
+                notes=notes,
+            )
+        )
+
+    def extend(self, entries: Iterable[ProvenanceEntry]) -> None:
+        for entry in entries:
+            self.entries.append(entry)
+
+    def clear(self) -> None:
+        self.entries.clear()
+
+    def to_markdown(self) -> str:
+        lines = ["| Dataset | Rows | Source | Notes |", "| --- | --- | --- | --- |"]
+        for entry in self.entries:
+            dataset = entry.dataset.replace("|", "\|")
+            row_range = entry.row_range.replace("|", "\|")
+            source = entry.source.replace("|", "\|")
+            notes = (entry.notes or "").replace("|", "\|")
+            lines.append(f"| {dataset} | {row_range} | {source} | {notes} |")
+        return "\n".join(lines)
+
+    def write(self, path: Path, *, heading: Optional[str] = None) -> None:
+        path = Path(path)
+        content = self.to_markdown()
+        if heading:
+            heading_line = clean_string(heading)
+            if heading_line:
+                content = f"{heading_line}\n\n{content}"
+        path.write_text(content + "\n", encoding="utf-8")

--- a/scripts/ingest/ingestlib/records.py
+++ b/scripts/ingest/ingestlib/records.py
@@ -1,0 +1,196 @@
+"""Typed representations of the mission datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .time import parse_get
+from .utils import clean_string, parse_json_field, split_multi_value
+
+
+@dataclass
+class EventRecord:
+    """Normalized view of a row from ``events.csv``."""
+
+    id: str
+    phase: str
+    get_open: Optional[str]
+    get_close: Optional[str]
+    get_open_seconds: Optional[float]
+    get_close_seconds: Optional[float]
+    craft: Optional[str]
+    system: Optional[str]
+    prerequisites: List[str]
+    autopilot_id: Optional[str]
+    checklist_id: Optional[str]
+    success_effects: Dict[str, Any]
+    failure_effects: Dict[str, Any]
+    notes: Optional[str]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "EventRecord":
+        autopilot_id = clean_string(
+            row.get("autopilot_script") or row.get("autopilot_id")
+        )
+        return cls(
+            id=clean_string(row.get("event_id")) or "",
+            phase=clean_string(row.get("phase")) or "",
+            get_open=clean_string(row.get("get_open")),
+            get_close=clean_string(row.get("get_close")),
+            get_open_seconds=parse_get(clean_string(row.get("get_open"))),
+            get_close_seconds=parse_get(clean_string(row.get("get_close"))),
+            craft=clean_string(row.get("craft")),
+            system=clean_string(row.get("system")),
+            prerequisites=split_multi_value(row.get("prerequisites")),
+            autopilot_id=autopilot_id,
+            checklist_id=clean_string(row.get("checklist_id")),
+            success_effects=parse_json_field(row.get("success_effects"), default={}),
+            failure_effects=parse_json_field(row.get("failure_effects"), default={}),
+            notes=clean_string(row.get("notes")),
+            raw=dict(row),
+        )
+
+
+@dataclass
+class ChecklistEntry:
+    """Single checklist step from ``checklists.csv``."""
+
+    checklist_id: str
+    title: str
+    nominal_get: Optional[str]
+    crew_role: Optional[str]
+    step_number: int
+    action: str
+    expected_response: Optional[str]
+    reference: Optional[str]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "ChecklistEntry":
+        step_number = int(row.get("step_number") or 0)
+        return cls(
+            checklist_id=clean_string(row.get("checklist_id")) or "",
+            title=clean_string(row.get("title")) or "",
+            nominal_get=clean_string(row.get("GET_nominal")),
+            crew_role=clean_string(row.get("crew_role")),
+            step_number=step_number,
+            action=clean_string(row.get("action")) or "",
+            expected_response=clean_string(row.get("expected_response")),
+            reference=clean_string(row.get("reference")),
+            raw=dict(row),
+        )
+
+
+@dataclass
+class AutopilotRecord:
+    """Metadata for automation scripts listed in ``autopilots.csv``."""
+
+    id: str
+    description: Optional[str]
+    script_path: Path
+    entry_conditions: Optional[str]
+    termination_conditions: Optional[str]
+    tolerances: Dict[str, Any]
+    propulsion: Dict[str, Any]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any], base_dir: Path) -> "AutopilotRecord":
+        script_fragment = clean_string(row.get("script_path")) or ""
+        script_path = (base_dir / script_fragment).resolve()
+        return cls(
+            id=clean_string(row.get("autopilot_id")) or "",
+            description=clean_string(row.get("description")),
+            script_path=script_path,
+            entry_conditions=clean_string(row.get("entry_conditions")),
+            termination_conditions=clean_string(row.get("termination_conditions")),
+            tolerances=parse_json_field(row.get("tolerances"), default={}),
+            propulsion=parse_json_field(row.get("propulsion"), default={}),
+            raw=dict(row),
+        )
+
+    def load_script(self) -> Dict[str, Any]:
+        """Load the JSON payload referenced by ``script_path``."""
+
+        return parse_json_field(self.script_path.read_text(encoding="utf-8"))
+
+
+@dataclass
+class PadRecord:
+    """Structured representation of ``pads.csv`` rows."""
+
+    id: str
+    purpose: Optional[str]
+    delivery_get: Optional[str]
+    valid_until: Optional[str]
+    parameters: Dict[str, Any]
+    source_ref: Optional[str]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "PadRecord":
+        return cls(
+            id=clean_string(row.get("pad_id")) or "",
+            purpose=clean_string(row.get("purpose")),
+            delivery_get=clean_string(row.get("GET_delivery")),
+            valid_until=clean_string(row.get("valid_until")),
+            parameters=parse_json_field(row.get("parameters"), default={}),
+            source_ref=clean_string(row.get("source_ref")),
+            raw=dict(row),
+        )
+
+
+@dataclass
+class FailureRecord:
+    """Failure taxonomy entry from ``failures.csv``."""
+
+    id: str
+    classification: str
+    trigger: Optional[str]
+    immediate_effect: Optional[str]
+    ongoing_penalty: Optional[str]
+    recovery_actions: Optional[str]
+    source_ref: Optional[str]
+    raw: Dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "FailureRecord":
+        return cls(
+            id=clean_string(row.get("failure_id")) or "",
+            classification=clean_string(row.get("classification")) or "",
+            trigger=clean_string(row.get("trigger")),
+            immediate_effect=clean_string(row.get("immediate_effect")),
+            ongoing_penalty=clean_string(row.get("ongoing_penalty")),
+            recovery_actions=clean_string(row.get("recovery_actions")),
+            source_ref=clean_string(row.get("source_ref")),
+            raw=dict(row),
+        )
+
+
+@dataclass
+class MissionData:
+    """Container aggregating the parsed mission datasets."""
+
+    events: List[EventRecord]
+    checklists: List[ChecklistEntry]
+    autopilots: List[AutopilotRecord]
+    pads: List[PadRecord]
+    failures: List[FailureRecord]
+    consumables: Dict[str, Any]
+    communications: Dict[str, Any]
+    thrusters: Dict[str, Any]
+
+    def event_map(self) -> Dict[str, EventRecord]:
+        return {event.id: event for event in self.events}
+
+    def checklist_index(self) -> Dict[str, List[ChecklistEntry]]:
+        index: Dict[str, List[ChecklistEntry]] = {}
+        for entry in self.checklists:
+            index.setdefault(entry.checklist_id, []).append(entry)
+        return index
+
+    def autopilot_map(self) -> Dict[str, AutopilotRecord]:
+        return {auto.id: auto for auto in self.autopilots}

--- a/scripts/ingest/ingestlib/time.py
+++ b/scripts/ingest/ingestlib/time.py
@@ -1,0 +1,145 @@
+"""Ground Elapsed Time helpers used across ingestion notebooks.
+
+The mission datasets rely on Apollo-style Ground Elapsed Time (GET)
+strings in ``HHH:MM:SS`` form. Notebooks and helper scripts repeatedly
+convert between strings, numeric seconds, and :class:`datetime.timedelta`
+values; keeping that logic in one place prevents subtle drift between
+the ingestion flow and the runtime simulator.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import math
+import re
+from typing import Iterable, Optional, Union
+
+_GET_PATTERN = re.compile(
+    r"^(?P<hours>\d+):(?P<minutes>[0-5]?\d):(?P<seconds>[0-5]?\d)(?:\.(?P<fraction>\d{1,3}))?$"
+)
+
+NumericLike = Union[int, float]
+GetLike = Union[str, NumericLike, timedelta]
+
+
+def parse_get(value: Optional[GetLike]) -> Optional[float]:
+    """Return the number of seconds represented by ``value``."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, timedelta):
+        return float(value.total_seconds())
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"Non-finite GET seconds value: {value!r}")
+        return float(value)
+
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+
+        match = _GET_PATTERN.match(trimmed)
+        if not match:
+            raise ValueError(f"Invalid GET string: {value!r}")
+
+        hours = int(match.group("hours"))
+        minutes = int(match.group("minutes"))
+        seconds = int(match.group("seconds"))
+        fraction = match.group("fraction")
+        fractional_seconds = int(fraction) / (10 ** len(fraction)) if fraction else 0.0
+        return float(hours * 3600 + minutes * 60 + seconds + fractional_seconds)
+
+    raise TypeError(f"Unsupported GET type: {type(value)!r}")
+
+
+def format_get(
+    seconds: Optional[NumericLike],
+    *,
+    precision: int = 0,
+    zero_pad_hours: int = 3,
+) -> Optional[str]:
+    """Return a canonical ``HHH:MM:SS`` representation for ``seconds``."""
+
+    if seconds is None:
+        return None
+
+    value = float(seconds)
+    if not math.isfinite(value):
+        raise ValueError(f"Non-finite GET value: {seconds!r}")
+
+    sign = "-" if value < 0 else ""
+    total = abs(value)
+
+    hours = int(total // 3600)
+    remaining = total - hours * 3600
+    minutes = int(remaining // 60)
+    remaining -= minutes * 60
+
+    if precision <= 0:
+        sec = int(round(remaining))
+        if sec >= 60:
+            minutes += 1
+            sec -= 60
+        if minutes >= 60:
+            hours += 1
+            minutes -= 60
+        return f"{sign}{hours:0{zero_pad_hours}d}:{minutes:02d}:{sec:02d}"
+
+    scale = 10**precision
+    sec = round(remaining * scale) / scale
+    if sec >= 60:
+        minutes += 1
+        sec -= 60
+    if minutes >= 60:
+        hours += 1
+        minutes -= 60
+
+    second_str = f"{sec:0{2 + (1 if precision else 0) + precision}.{precision}f}".zfill(2 + 1 + precision)
+    if precision > 0 and second_str.find(".") == 1:
+        second_str = f"0{second_str}"
+
+    return f"{sign}{hours:0{zero_pad_hours}d}:{minutes:02d}:{second_str}"
+
+
+def normalize_get(value: Optional[GetLike], *, precision: int = 0) -> Optional[str]:
+    """Coerce ``value`` into a canonical GET string or ``None``."""
+
+    seconds = parse_get(value)
+    if seconds is None:
+        return None
+    return format_get(seconds, precision=precision)
+
+
+def ensure_monotonic(get_values: Iterable[Optional[GetLike]]) -> bool:
+    """Return ``True`` if the GET sequence is strictly non-decreasing."""
+
+    previous = None
+    for raw in get_values:
+        current = parse_get(raw)
+        if current is None:
+            continue
+        if previous is not None and current < previous:
+            return False
+        previous = current
+    return True
+
+
+def to_timedelta(value: Optional[GetLike]) -> Optional[timedelta]:
+    """Return ``value`` as :class:`datetime.timedelta` if possible."""
+
+    seconds = parse_get(value)
+    if seconds is None:
+        return None
+    return timedelta(seconds=seconds)
+
+
+def add_seconds(value: Optional[GetLike], delta_seconds: NumericLike) -> Optional[str]:
+    """Add ``delta_seconds`` to ``value`` and return a canonical string."""
+
+    base = parse_get(value)
+    if base is None:
+        return None
+    return format_get(base + float(delta_seconds))

--- a/scripts/ingest/ingestlib/utils.py
+++ b/scripts/ingest/ingestlib/utils.py
@@ -1,0 +1,84 @@
+"""Shared parsing helpers for ingestion notebooks."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Iterable, List, Optional
+
+_SEPARATORS = (',', ';', '|')
+
+
+def clean_string(value: Optional[Any]) -> Optional[str]:
+    """Return ``value`` as a stripped string or ``None`` if blank."""
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value).strip() or None
+
+
+def parse_json_field(value: Any, default: Any = None) -> Any:
+    """Parse a JSON fragment stored in a CSV cell.
+
+    Empty strings resolve to ``default`` (which defaults to ``None``).
+    Exceptions bubble up so notebooks surface malformed input early.
+    """
+
+    text = clean_string(value)
+    if text is None:
+        return default
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        normalized = text.replace('\"', '"')
+        if normalized != text:
+            try:
+                return json.loads(normalized)
+            except json.JSONDecodeError:
+                pass
+        raise ValueError(f"Invalid JSON payload: {text!r}") from exc
+
+
+def split_multi_value(value: Any) -> List[str]:
+    """Split a multi-value cell into a list of identifiers."""
+
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [item.strip() for item in value if clean_string(item)]
+
+    text = str(value).strip()
+    if not text:
+        return []
+
+    for separator in _SEPARATORS:
+        text = text.replace(separator, ' ')
+    return [token for token in text.split() if token]
+
+
+def safe_float(value: Any) -> Optional[float]:
+    """Convert ``value`` to ``float`` while ignoring blanks."""
+
+    text = clean_string(value)
+    if text is None:
+        return None
+    try:
+        number = float(text)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid numeric value: {value!r}") from exc
+    if math.isnan(number) or math.isinf(number):
+        raise ValueError(f"Non-finite numeric value: {value!r}")
+    return number
+
+
+def iter_non_null(values: Iterable[Any]):
+    """Yield non-empty values from ``values``."""
+
+    for value in values:
+        if clean_string(value) is None:
+            continue
+        yield value

--- a/scripts/ingest/ingestlib/validation.py
+++ b/scripts/ingest/ingestlib/validation.py
@@ -1,0 +1,212 @@
+"""Lightweight validation for ingestion outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .records import MissionData
+from .time import parse_get
+
+_ALLOWED_FAILURE_CLASSES = {"Recoverable", "Hard", "Technical"}
+
+
+@dataclass
+class ValidationIssue:
+    level: str  # "error" or "warning"
+    category: str
+    message: str
+    context: Dict[str, Any]
+
+    def __lt__(self, other: "ValidationIssue") -> bool:
+        return (self.level, self.category, self.message) < (
+            other.level,
+            other.category,
+            other.message,
+        )
+
+
+def validate_mission_data(mission_data: MissionData) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+
+    event_map = mission_data.event_map()
+    checklist_index = mission_data.checklist_index()
+    autopilot_map = mission_data.autopilot_map()
+    failure_ids = {failure.id for failure in mission_data.failures}
+
+    # Events
+    for event in mission_data.events:
+        if event.get_open_seconds is not None and event.get_close_seconds is not None:
+            if event.get_close_seconds < event.get_open_seconds:
+                issues.append(
+                    ValidationIssue(
+                        level="error",
+                        category="events",
+                        message="Event window closes before it opens",
+                        context={"event_id": event.id},
+                    )
+                )
+
+        for prereq in event.prerequisites:
+            if prereq not in event_map:
+                issues.append(
+                    ValidationIssue(
+                        level="error",
+                        category="events",
+                        message="Missing prerequisite reference",
+                        context={"event_id": event.id, "missing": prereq},
+                    )
+                )
+
+        if event.autopilot_id and event.autopilot_id not in autopilot_map:
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    category="events",
+                    message="Unknown autopilot reference",
+                    context={"event_id": event.id, "autopilot_id": event.autopilot_id},
+                )
+            )
+
+        if event.checklist_id and event.checklist_id not in checklist_index:
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    category="events",
+                    message="Unknown checklist reference",
+                    context={"event_id": event.id, "checklist_id": event.checklist_id},
+                )
+            )
+
+        referenced_failure = _extract_failure_id(event.failure_effects)
+        if referenced_failure and referenced_failure not in failure_ids:
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    category="events",
+                    message="Unknown failure reference",
+                    context={"event_id": event.id, "failure_id": referenced_failure},
+                )
+            )
+
+    # Checklists
+    for checklist_id, steps in checklist_index.items():
+        numbers = sorted(step.step_number for step in steps)
+        for index, step_number in enumerate(numbers, start=1):
+            if step_number != index:
+                issues.append(
+                    ValidationIssue(
+                        level="warning",
+                        category="checklists",
+                        message="Checklist step numbers are not sequential",
+                        context={"checklist_id": checklist_id, "expected": index, "found": step_number},
+                    )
+                )
+                break
+
+    # Autopilots
+    for autopilot in mission_data.autopilots:
+        if not autopilot.script_path.is_file():
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    category="autopilots",
+                    message="Autopilot script file is missing",
+                    context={"autopilot_id": autopilot.id, "path": str(autopilot.script_path)},
+                )
+            )
+            continue
+
+        try:
+            payload = autopilot.load_script()
+        except Exception as exc:  # pylint: disable=broad-except
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    category="autopilots",
+                    message="Failed to parse autopilot script JSON",
+                    context={"autopilot_id": autopilot.id, "error": str(exc)},
+                )
+            )
+            continue
+
+        sequence = payload.get("sequence")
+        if isinstance(sequence, list):
+            previous = None
+            for entry in sequence:
+                time_value = entry.get("time") if isinstance(entry, dict) else None
+                if time_value is None:
+                    continue
+                try:
+                    numeric = float(time_value)
+                except (TypeError, ValueError):
+                    issues.append(
+                        ValidationIssue(
+                            level="error",
+                            category="autopilots",
+                            message="Invalid command time value",
+                            context={"autopilot_id": autopilot.id, "command": entry},
+                        )
+                    )
+                    continue
+                if previous is not None and numeric < previous:
+                    issues.append(
+                        ValidationIssue(
+                            level="warning",
+                            category="autopilots",
+                            message="Autopilot commands are not sorted by time",
+                            context={"autopilot_id": autopilot.id},
+                        )
+                    )
+                    break
+                previous = numeric
+
+    # PADs
+    for pad in mission_data.pads:
+        for field_name, value in (
+            ("GET_delivery", pad.delivery_get),
+            ("valid_until", pad.valid_until),
+        ):
+            if value is None:
+                continue
+            try:
+                parse_get(value)
+            except Exception as exc:  # pylint: disable=broad-except
+                issues.append(
+                    ValidationIssue(
+                        level="error",
+                        category="pads",
+                        message=f"Invalid GET string in {field_name}",
+                        context={"pad_id": pad.id, "value": value, "error": str(exc)},
+                    )
+                )
+
+    # Failures
+    for failure in mission_data.failures:
+        if failure.classification not in _ALLOWED_FAILURE_CLASSES:
+            issues.append(
+                ValidationIssue(
+                    level="warning",
+                    category="failures",
+                    message="Unknown failure classification",
+                    context={"failure_id": failure.id, "classification": failure.classification},
+                )
+            )
+
+    issues.sort()
+    return issues
+
+
+def _extract_failure_id(effect: Any) -> Optional[str]:
+    if isinstance(effect, dict):
+        if "failure_id" in effect:
+            value = effect.get("failure_id")
+            return str(value) if value is not None else None
+        for nested in effect.values():
+            candidate = _extract_failure_id(nested)
+            if candidate:
+                return candidate
+    return None
+
+
+__all__ = ["ValidationIssue", "validate_mission_data"]


### PR DESCRIPTION
## Summary
- add the `scripts/ingest/ingestlib` package with GET utilities, typed record loaders, validation helpers, and provenance table support for the ingestion notebooks
- refresh the ingestion workspace and data documentation to describe the new helpers and show how to import them from notebooks or standalone scripts
- mention the shared library in the top-level README so contributors can find the tooling quickly

## Testing
- PYTHONPATH=scripts/ingest python - <<'PY' ... (load_mission_data + validate_mission_data sample)
- PYTHONPATH=scripts/ingest python - <<'PY' ... (load autopilot script sample)


------
https://chatgpt.com/codex/tasks/task_e_68cae7a07e088323a1a6e4e8d6af0897