### PR TITLE
Document UI architecture and audio routing plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - `UiFrameBuilder` in [`js/src/hud/uiFrameBuilder.js`](js/src/hud/uiFrameBuilder.js) consolidates scheduler, resource, autopilot, checklist, and manual queue state into deterministic `ui_frame` snapshots (documented in [`docs/ui/ui_frame_reference.md`](docs/ui/ui_frame_reference.md)) so the CLI HUD and upcoming Navigation/Controls/Systems views share a single data contract.
 - Milestone M3 UI, HUD, and audio telemetry planning in [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) defines presentation-layer architecture, cue taxonomy, and accessibility handoff targets for the JS prototype and N64 port.
 - Detailed HUD and pane layout specification in [`docs/ui/hud_layout.md`](docs/ui/hud_layout.md) locks in the Always-On HUD modules, Navigation/Controls/Systems view grids, tile-mode presets, and data-binding strategy that the M3 UI build will implement across the web and N64 targets.
+- UI component architecture blueprint in [`docs/ui/component_architecture.md`](docs/ui/component_architecture.md) maps the pane/component tree, `ui_frame` ingestion flow, tile workspace persistence, and accessibility hooks that keep the Always-On HUD authoritative across web and N64 builds.
+- Audio cue taxonomy and routing plan in [`docs/ui/audio_cue_taxonomy.md`](docs/ui/audio_cue_taxonomy.md) defines cue categories, priority/ducking rules, dataset hooks, and asset specs so the upcoming dispatcher can balance alerts, callouts, ambience, and UI feedback consistently.
 - Milestone M4 N64 port plan in [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) maps the libdragon architecture, rendering/audio budgets, input scheme, and asset pipeline for the hardware build.
 - Milestone M5 content integration roadmap in [`docs/milestones/M5_CONTENT_PASS.md`](docs/milestones/M5_CONTENT_PASS.md) itemizes the remaining dataset ingestion work, contingency branches, and ingestion tooling required for the full mission graph.
 - Milestone M6 fidelity pass outline in [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) defines calibration targets for timelines, propulsion, resources, and communications against Apollo 11 telemetry.
@@ -58,6 +60,8 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/ui/dsky_reference.md`](docs/ui/dsky_reference.md) – DSKY macro catalog covering alignment, burn, docking, and entry Verb/Noun pairs with prerequisite logic.
 - [`docs/ui/json_schemas.md`](docs/ui/json_schemas.md) – JSON schema definitions for upcoming checklist, panel, and workspace data packs consumed by the UI layer.
 - [`docs/ui/hud_layout.md`](docs/ui/hud_layout.md) – HUD band, pane layouts, tile-mode presets, and accessibility hooks for the Milestone M3 presentation layer.
+- [`docs/ui/component_architecture.md`](docs/ui/component_architecture.md) – Component tree, frame ingestion pipeline, tile workspace behavior, and accessibility hooks for the web/N64 UI builds.
+- [`docs/ui/audio_cue_taxonomy.md`](docs/ui/audio_cue_taxonomy.md) – Cue categories, priority routing, dataset integration, and asset specs for the mission audio pipeline.
 - [`docs/scoring/commander_rating.md`](docs/scoring/commander_rating.md) – Commander rating model, telemetry inputs, and weighting used by the simulation score system.
 
 ## Contribution Notes

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -52,6 +52,7 @@ Each event has a window, manual inputs, autopilot scripts, telemetry, and failur
 - Text console for PAD uplinks and autopilot feedback.
 - Failure breadcrumbs highlighting causal chains (e.g., "PTC OFF → cryo boiloff ↑ → fuel cell ΔP ↓").
 - Panel switch maps, DSKY macro catalog, and workspace schemas documented in [`docs/ui/`](ui) to keep UI prerequisites aligned with mission procedures.
+- Presentation-layer component boundaries and update cadence are outlined in [`docs/ui/component_architecture.md`](ui/component_architecture.md), while cue categories, priority routing, and asset specs live in [`docs/ui/audio_cue_taxonomy.md`](ui/audio_cue_taxonomy.md) to steer Milestone M3 implementation.
 
 ## 5. Failure Taxonomy
 - **Success:** All milestones within spec.

--- a/docs/data/INGESTION_PIPELINE.md
+++ b/docs/data/INGESTION_PIPELINE.md
@@ -20,8 +20,9 @@ The recommended execution order keeps downstream dependencies satisfied:
 6. `failure_taxonomy.ipynb`
 7. `communications_trends.ipynb`
 8. `consumables_budget.ipynb`
+9. `audio_cues.ipynb`
 
-Running notebooks in this sequence ensures that event windows, checklists, PADs, autopilot metadata, and failure hooks stay synchronized before communications and consumables analytics recalculate their derivatives.
+Running notebooks in this sequence ensures that event windows, checklists, PADs, autopilot metadata, and failure hooks stay synchronized before communications, consumables, and audio cue analytics recalculate their derivatives.
 
 ## Shared Notebook Helpers
 

--- a/docs/data/VALIDATION_CHECKS.md
+++ b/docs/data/VALIDATION_CHECKS.md
@@ -45,5 +45,6 @@ The command loads the CSV and JSON packs under `docs/data/`, performs consistenc
 - Future EVA extensions or DSN updates should extend these checks so nested effect payloads (e.g., `communications.next_window_open_get`, `surface_ops.eva2_complete`) stay validated as new fields appear.
 - Planned notebooks under `scripts/ingest/` can re-use the validator’s helper functions for GET parsing and reference verification so manual analyses stay aligned with the automated sweep.
 - When mission scoring hooks mature, incorporate regression checks that assert metric ranges (Δv margins, propellant draw) remain within expected tolerances.
+- Upcoming audio cue fields (`audio_cue`, `audio_channel`, DSN handover cues) should be wired into the validator once the datasets land so cue IDs resolve to the shared `audio_cues.json` pack and bus names stay canonical.
 
 Maintaining these checks keeps the mission data trustworthy for both the JS prototype and the eventual Nintendo 64 build while reducing manual verification overhead as Milestone M0 evolves.

--- a/docs/milestones/M3_UI_AUDIO.md
+++ b/docs/milestones/M3_UI_AUDIO.md
@@ -12,9 +12,9 @@ port.
 - Document cross-platform considerations so the eventual N64 build can reproduce the UI and audio layer within its budgets.
 
 ## Deliverables
-- UI state aggregator and presentation layer design notes for the JS prototype (component tree, update cadence, data bindings).
+- UI state aggregator and presentation layer design notes for the JS prototype (component tree, update cadence, data bindings) documented in [`docs/ui/component_architecture.md`](../ui/component_architecture.md).
 - HUD layout specifications including timing blocks, event stack, resource gauges, and maneuver widgets.
-- Audio cue taxonomy mapped to mission events and failure classes with playback priority rules and asset references.
+- Audio cue taxonomy mapped to mission events and failure classes with playback priority rules and asset references, captured in [`docs/ui/audio_cue_taxonomy.md`](../ui/audio_cue_taxonomy.md).
 - Logging, replay, and accessibility guidelines covering color use, captioning, and control remapping hooks.
 - Panel hierarchy, DSKY macro catalog, and JSON data schema references in [`docs/ui/`](../ui) to guide panel highlighting, DSKY macros, and tile-mode presets.
 

--- a/docs/ui/audio_cue_taxonomy.md
+++ b/docs/ui/audio_cue_taxonomy.md
@@ -1,0 +1,126 @@
+# Audio Cue Taxonomy & Routing Plan
+
+This document defines how the simulator categorizes, prioritizes, and
+routes audio cues during Milestone M3. It aligns with the HUD and
+component architecture notes so mission events, failures, and user
+interactions share a consistent soundscape that can later be ported to
+the Nintendo 64 audio mixer.
+
+## Objectives
+
+- Map the mission timeline, checklist flow, and failure taxonomy to a
+  deterministic audio event table.
+- Establish a priority-driven dispatcher that balances ambience, voice,
+  alerts, and UI feedback without clipping or starving critical cues.
+- Document asset requirements, loudness targets, and looping guidelines
+  for both the Web Audio prototype and libdragon (ADPCM) port.
+- Capture dataset hooks so ingestion scripts can annotate mission packs
+  with cue identifiers.
+
+## Cue Categories
+
+| Category | Examples | Trigger Sources | Notes |
+| --- | --- | --- | --- |
+| **Alerts** | Master alarm, master caution, guidance mode change beeps | `ResourceSystem` thresholds, `failures.csv`, autopilot runner | Highest priority; interrupt ambience and voice as needed. |
+| **Mission Callouts** | "Go for TLI", "You are Go for Docking", EVA timeline callouts | `events.csv` (`audio_cue` field), PAD deliveries, manual queue acknowledgements | Follow historical cadence; include subtitles/log entries. |
+| **Checklist Feedback** | Step complete ticks, invalid toggle buzz | Checklist manager transitions, DSKY macro validation | Surface within Controls view; duck under alerts but above ambience. |
+| **Ambient Beds** | Cabin hum, radio static, LM powerdown hum | Scheduler state (CSM/LM active), craft docking state, time of mission | Persist until replaced; fade/duck around alerts. |
+| **UI Interactions** | Tile drag snap, workspace save confirmation, console filter toggles | UI component events | Short <250 ms cues; never pre-empt higher categories. |
+| **Telemetry Hints** | DSN acquisition tone, PTC entry beep, burn start/stop chirps | Event scheduler, autopilot runner, communications scheduler | Provide additional situational awareness; share priority with checklist feedback. |
+
+## Priority & Mixing Rules
+
+1. **Alert Stack (Priority 100–80):** Master alarms (100) pre-empt all
+   other cues and mute ambience until resolved. Caution/warning tones
+   (90–80) duck ambience by −12 dB and voice by −6 dB while playing.
+2. **Mission Callouts (70–60):** Routed to the dialogue bus. Alerts can
+   interrupt; otherwise callouts play sequentially. Provide 0.5 s of
+   silence between callouts to avoid crowding transcripts.
+3. **Telemetry & Checklist (50–40):** Share a mid-priority bus. When
+   simultaneous, telemetry hints queue ahead of checklist confirmation
+   ticks so maneuver cues remain intelligible.
+4. **UI Interactions (30):** Fire immediately unless the channel already
+   plays an interaction cue; in that case, retrigger after 100 ms to avoid
+   stutter.
+5. **Ambience (10):** Looped beds that fade in/out over 3 s. Alert
+   categories can temporarily mute or duck them, after which ambience
+   recovers to −16 LUFS integrated.
+
+Each cue registers `{ priority, bus, duckingRules, cooldownSeconds }` so
+runtime systems can enforce deterministic mixing without dynamic
+allocation.
+
+## Dataset Integration
+
+- **Events CSV:** Add optional `audio_cue` (string) and `audio_channel`
+  (enum) columns. Example values:
+  - `audio_cue`: `calouts.go_for_tli`
+  - `audio_channel`: `dialogue`
+- **Failures CSV:** Introduce `audio_cue_warning` / `audio_cue_failure`
+  fields referencing alert IDs (e.g., `alerts.master_alarm`).
+- **Checklists CSV:** Allow `audio_cue_complete` for steps requiring
+  bespoke confirmations (e.g., docking latch).
+- **Communications Trends JSON:** Append `cue_on_acquire` and
+  `cue_on_loss` to trigger DSN tones during handovers.
+
+The ingestion notebooks emit consolidated cue tables under
+`docs/data/audio_cues.json` (planned) listing cue metadata
+(`id`, `category`, `assets`, `loop`, `lengthSeconds`, `loudnessLufs`).
+`validateMissionData.js` will parse the new columns, ensuring cue IDs map
+back to this pack and enforcing allowable channel names.
+
+## Runtime Dispatcher
+
+1. **Event Listener:** Subscribes to scheduler, resource, checklist, and
+   UI domains. Each signal emits `{ id, priority, bus, payload }`.
+2. **Deduplication:** Repeated cues within `cooldownSeconds` are collapsed
+   unless flagged `allowRetrigger` (e.g., manual caution button).
+3. **Queue Manager:** Maintains per-bus queues ordered by priority and
+   timestamp. Alerts bypass the queue and claim the output immediately.
+4. **Renderer Binding:**
+   - **Web:** Web Audio API with GainNode hierarchies (`master > bus > cue`).
+   - **N64:** Pre-allocated libdragon voices per bus (alerts, dialogue,
+     telemetry, UI, ambience). Ducking modifies bus gain values stored in
+     a fixed-point table to avoid floating-point cost.
+5. **Logging:** Every cue dispatch writes an entry to the mission log and
+   console dock (`type: 'audio', id, priority, source`). Replay tools can
+   reconstruct the audio timeline without real-time synthesis.
+
+## Asset Specifications
+
+- **Format:**
+  - Web: 48 kHz 16-bit PCM WAV masters, converted to Ogg for distribution.
+  - N64: 22.05 kHz mono ADPCM (Yamaha ADPCM-A) with loop points aligned to
+    zero crossings.
+- **Loudness:** Normalize to −16 LUFS integrated, peak ≤ −1 dBFS. Alerts
+  may peak at −3 dBFS for clarity but respect the integrated target.
+- **Length:** Target <4 s for alerts and telemetry cues, <15 s for callouts
+  (matching transcript length), ambience loops ~60 s before repeating.
+- **Naming:** `category_subcategory_identifier__version.ext` (e.g.,
+  `alert_master_alarm__v1.wav`). Replay logs reference cue IDs, not file
+  names, allowing asset iteration without touching mission data.
+
+## Accessibility & Localization
+
+- Provide subtitle text and phonetic hints in `audio_cues.json` for all
+  dialogue. The UI surfaces transcripts in the Console Dock and optional
+  caption overlay.
+- Expose a master "Text-to-Speech" toggle that mirrors callouts via
+  synthesized speech for accessibility or placeholder use before VO
+  recording completes.
+- Keep cue metadata language-agnostic; localization swaps the asset path
+  while preserving cue IDs and scheduling rules.
+
+## Outstanding Tasks
+
+- Author ingestion notebooks to populate `audio_cues.json` from annotated
+  callout scripts and alert tables.
+- Extend `validateMissionData.js` with schema checks once the cue fields
+  land in the datasets.
+- Prototype the dispatcher in the JS build, initially logging cue order
+  and ducking operations to validate timing before integrating actual audio
+  playback.
+
+This taxonomy ensures mission-critical alerts retain priority while still
+supporting immersive ambience, historical callouts, and responsive UI
+feedback across both delivery platforms.

--- a/docs/ui/component_architecture.md
+++ b/docs/ui/component_architecture.md
@@ -1,0 +1,163 @@
+# UI Component Architecture Blueprint
+
+This blueprint captures how the JavaScript prototype will organize the
+Navigation, Controls, Systems, and Tile Mode presentations around the
+shared `ui_frame` contract. It complements [`hud_layout.md`](hud_layout.md)
+by focusing on component boundaries, update cadence, and the data flows
+that keep the three-pane rhythm aligned with mission truth.
+
+## Goals
+
+- Present a deterministic, low-latency view of mission state that mirrors
+the Apollo checklist cadence documented in `docs/PROJECT_PLAN.md`.
+- Keep the Always-On HUD visible across Navigation/Controls/Systems/Tiles
+  so GET, upcoming events, Δv, resources, and alarms remain in view.
+- Reuse the same component tree for the web and N64 builds, differing only
+  in the rendering primitives (DOM/Canvas vs. libdragon line lists).
+- Allow rapid focus shifts (keyboard/controller hotkeys) without tearing
+  or desynchronizing with the simulation loop.
+
+## Frame Ingestion Pipeline
+
+1. **Simulation Loop:** `Simulation.run()` advances the mission at a fixed
+   tick rate (default 20 Hz) and notifies the HUD layer once per
+   `renderIntervalSeconds` (default 600 s for the CLI, lower for the visual
+   HUD).
+2. **UiFrameBuilder:** `hud/uiFrameBuilder.js` snapshots scheduler,
+   resource, checklist, manual action, and autopilot state into a
+   deterministic `ui_frame` payload (see
+   [`ui_frame_reference.md`](ui_frame_reference.md)).
+3. **Presentation Store:** The UI keeps a read-only store (immutable frame
+   cache) keyed by `generatedAtSeconds`. Views subscribe to the latest
+   frame; diffing happens at the pane boundary so widgets only re-render
+   when their subtree changes.
+4. **Renderers:** Navigation, Controls, Systems, and Tile Mode renderers
+   consume the normalized frame plus pane-specific derived data (e.g.,
+   plotted trajectories, checklist callouts).
+
+All panes treat `ui_frame` as the single source of truth. Side effects
+(switch toggles, DSKY macros) dispatch actions back to the simulation via
+an input bus that mirrors the `ManualActionQueue` so manual/autopilot
+parity stays intact.
+
+## Component Tree Overview
+
+```
+<App>
+  <AlwaysOnHud>
+    <TimeBlock />
+    <EventStack />
+    <ResourceBands />
+    <ManeuverWidget />
+    <ChecklistChip />
+    <CommsLamp />
+    <AlarmCluster />
+  </AlwaysOnHud>
+  <ViewRouter>
+    <NavigationView /> | <ControlsView /> | <SystemsView />
+  </ViewRouter>
+  <TileWorkspace />
+  <ConsoleDock />
+  <HotkeyOverlay />
+</App>
+```
+
+- **App:** Bootstraps frame subscription, keyboard/controller bindings,
+  and persistence (workspace JSON, checklist completion).
+- **AlwaysOnHud:** Anchored band that never unmounts. Consumes the time,
+  events, resources, communications, and alerts slices of the frame. Lamp
+  states (caution/warning/failure) inherit resource thresholds from the
+  `ResourceSystem`.
+- **ViewRouter:** Switches between Navigation/Controls/Systems panes.
+  `Tab`/`Shift+Tab` (or controller shoulder buttons) advance views; `1/2/3`
+  jump directly.
+- **TileWorkspace:** Hidden by default; toggled via `T`. Inherits the same
+  widget components but wraps them in a draggable/resizable manager that
+  saves presets to `workspaces.json`.
+- **ConsoleDock:** Scrollback log for mission events, autopilot transitions,
+  manual queue actions, and audio cue triggers. Chips filter by category
+  (All / Events / Autopilot / Audio / Failures).
+- **HotkeyOverlay:** Briefly surfaces when users invoke shortcuts, aiding
+  learnability and controller remapping.
+
+## Navigation View
+
+| Region | Components | Data Bindings |
+| --- | --- | --- |
+| Trajectory Canvas | `<TrajectoryPlot />` | `frame.events.upcoming`, mission ephemeris stream (patched conics) |
+| Navball / Attitude | `<Navball />`, `<PtcIndicator />` | `frame.autopilot`, `frame.resources.thermal`, attitude quaternions |
+| State Vector | `<StateVectorPanel />` | `frame.resources.deltaV`, guidance errors, current burn metrics |
+| Timeline Ribbon | `<TimelineRibbon />` | Scheduler history, upcoming events (5-entry window) |
+
+Interactions push actions onto the manual queue: selecting a timeline
+marker focuses the checklist and primes DSKY macros.
+
+## Controls View
+
+| Region | Components | Data Bindings |
+| --- | --- | --- |
+| Panel Rail | `<PanelList />` | Checklist metadata, `panels.json` hierarchy |
+| Active Panel | `<PanelDiagram />`, `<SwitchTooltip />` | Panel control states, checklist highlights, dependencies |
+| DSKY | `<DskyShell />`, `<VerbNounDisplay />` | AGC program state, macro previews, manual input buffer |
+| Checklist Lane | `<ChecklistScroller />`, `<StepCard />` | Active checklist from `frame.checklists`, manual queue feedback |
+
+DSKY macros validate required switch states (`panels.json` dependencies)
+before dispatching AGC commands. Failed predicates light the relevant
+controls and surface recovery hints.
+
+## Systems View
+
+| Region | Components | Data Bindings |
+| --- | --- | --- |
+| Power Buses | `<PowerGrid />` | `frame.resources.power`, fuel cell telemetry, caution thresholds |
+| Propellant Overview | `<PropellantDeck />` | Tank metrics (`frame.resources.propellant.tanks`), burn totals |
+| Thermal / Cryo | `<ThermalPanel />` | Cryo boiloff, tank temperatures, PTC status |
+| Comms Windows | `<CommsSchedule />` | `frame.resources.communications.current/next`, DSN availability |
+| Trends & Fault Log | `<TrendGraphs />`, `<FaultTimeline />` | Resource history buffers, mission failures |
+
+## Tile Mode Windows
+
+Tile Mode reuses the widgets above as draggable tiles. Layout metadata
+comes from `workspaces.json`; users can save/load presets. Focus mode
+fills the viewport with a single tile while the Always-On HUD remains
+pinned per the instructions in [`AGENTS.md`](AGENTS.md).
+
+## Update Cadence & Performance Targets
+
+- **Frame Rate:** The interactive HUD targets 20 Hz updates; heavy charts
+  (trajectory plot, trend graphs) may internally throttle to 5–10 Hz while
+  interpolating between frames.
+- **Animation Budget:** Transitions and tile drags aim for <8 ms/frame on
+  desktop browsers, leaving headroom for simulation work. N64 builds budget
+  ≤1 ms of RSP time for HUD line lists per frame.
+- **Diff Strategy:** Widgets compare shallow hashes of their frame slices
+  to avoid re-rendering unchanged data. Manual queue acknowledgements feed
+  optimistic UI updates, rolling back if the simulation rejects an action.
+
+## Accessibility Hooks
+
+- Keyboard/controller mappings follow the hotkey guide in
+  [`AGENTS.md`](AGENTS.md) and `hud_layout.md`. Tooltips display shortcut
+  hints when users hover or focus interactive controls.
+- High-contrast mode swaps the HUD palette and thickens vector strokes.
+  The toggle lives in the Console Dock menu and persists in workspace
+  presets.
+- Checklist narration exposes SR-friendly status strings (e.g.,
+  “Checklist: P52 Realign, Step 4 of 9, Awaiting IMU Gimbal Null”). Voice
+  playback hooks route through the audio dispatcher detailed in
+  [`audio_cue_taxonomy.md`](audio_cue_taxonomy.md).
+
+## Persistence & Replay
+
+- **Workspace State:** Saved to `workspaces.json` via the ingestion
+  pipeline so curated layouts ship with the game while players can export
+  personal presets.
+- **Checklist Progress:** Stored per mission run in log files, enabling the
+  parity harness to replay manual sessions with identical UI state.
+- **Console Log:** Frame-aligned entries allow replay tooling to reconstruct
+  HUD panels and audio cues deterministically, satisfying Milestone M3
+  regression requirements.
+
+This architecture keeps mission truth centralized, ensures the Always-On
+HUD remains authoritative, and prepares both the web and N64 builds for
+shared UI assets without duplicating logic per platform.


### PR DESCRIPTION
## Summary
- add a UI component architecture blueprint that maps the Navigation, Controls, Systems, and Tile Mode layouts onto the shared `ui_frame`
- define the mission audio cue taxonomy, priority routing, dataset hooks, and asset specifications for the upcoming dispatcher
- cross-link the new plans from the project plan, README, ingestion workflow, milestone notes, and validation checklist

## Testing
- no tests were run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cb14fb27c883239b880a23bf605f17