### PR TITLE
Add DSKY entry support to manual action queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Milestone M6 fidelity pass outline in [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) defines calibration targets for timelines, propulsion, resources, and communications against Apollo 11 telemetry.
 - Milestone M7 stability plan in [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) details soak-testing strategy, fault injection coverage, and automation expectations for release readiness.
 - Manual action recorder in [`js/src/logging/manualActionRecorder.js`](js/src/logging/manualActionRecorder.js) can capture auto-advanced checklist steps and export them via the CLI `--record-manual-script` flag for deterministic manual-vs-auto parity runs.
+- `ManualActionQueue` now accepts `dsky_entry` actions so scripted runs and future UI flows can log Verb/Noun inputs and macro payloads for AGC integration while keeping the mission log authoritative.
 - Ingestion workflow planning under [`scripts/ingest/`](scripts/ingest/README.md) and [`docs/data/INGESTION_PIPELINE.md`](docs/data/INGESTION_PIPELINE.md) now documents how future dataset updates move from annotated sources into the CSV/JSON packs, including notebook sequencing, validation checkpoints, and automation hooks.
 - Shared Python helpers under [`scripts/ingest/ingestlib/`](scripts/ingest/ingestlib) expose GET utilities, typed dataset loaders, validation routines, and provenance table builders so notebooks and future automation reuse a single source of truth.
 

--- a/docs/data/manual_scripts/README.md
+++ b/docs/data/manual_scripts/README.md
@@ -8,7 +8,7 @@ Scripts are UTF-8 JSON files. The root can either be an array of action objects 
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `type` | ✔️ | `"checklist_ack"`, `"resource_delta"`, or `"propellant_burn"`. |
+| `type` | ✔️ | `"checklist_ack"`, `"resource_delta"`, `"propellant_burn"`, or `"dsky_entry"`. |
 | `get` / `time` / `get_seconds` | ✔️ | Mission time to execute. Accepts `HHH:MM:SS` or seconds. |
 | `id` |  | Optional label for log output; defaults to `<type>_<index>`. |
 | `retry_window_seconds` / `retry_until` |  | Optional retry window if prerequisites are not yet met (e.g., event still arming). |
@@ -53,6 +53,17 @@ Convenience wrapper that subtracts propellant from a named tank. Fields:
 - `tank` / `tank_key` / `propellant` (required) – Tank identifier (e.g., `"csm_rcs"`, `"lm_descent"`).
 - `amount_kg` or `amount_lb` (required) – Consumption amount; pounds are converted to kilograms automatically.
 
+#### `dsky_entry`
+
+Logs a DSKY macro or manual keypad entry for upcoming AGC integration. Fields:
+
+- `macro` / `macro_id` (optional) – Macro identifier from [`docs/ui/dsky_reference.md`](../../ui/dsky_reference.md).
+- `verb` and `noun` (required when `macro` omitted) – Numeric Verb/Noun pair.
+- `registers` / `values` (optional) – Object or array of register contents (`{"R1": "+00000"}`) that the entry supplies.
+- `sequence` / `inputs` (optional) – Ordered keypress list (`["VERB 21", "NOUN 33", "PRO"]`).
+- `program` (optional) – AGC program label for logging.
+- `note` (optional) – Freeform annotation recorded alongside the log entry.
+
 ## Example
 
 ```json
@@ -85,6 +96,21 @@ Convenience wrapper that subtracts propellant from a named tank. Fields:
     },
     "source": "manual_script",
     "note": "Load shed after consumables review"
+  },
+  {
+    "id": "LOAD_MCC1_PAD",
+    "type": "dsky_entry",
+    "get": "009:35:00",
+    "macro": "V21N33_LOAD_DV",
+    "verb": 21,
+    "noun": 33,
+    "registers": {
+      "R1": "+00020",
+      "R2": "+00000",
+      "R3": "-00005"
+    },
+    "sequence": ["VERB 21", "NOUN 33", "+00020", "+00000", "-00005", "PRO"],
+    "note": "Pre-fill MCC-1 ΔV vector"
   }
 ]
 ```


### PR DESCRIPTION
## Summary
- extend the manual action queue with support for `dsky_entry` actions that log Verb/Noun inputs and track metrics
- document the new DSKY entry script shape and example for manual action scripts
- note the queue enhancement in the project overview so upcoming UI and AGC work can rely on it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb1dfc15a88323912dfad63a8f720f