### PR TITLE
Document manual action queue integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Manual action recorder in [`js/src/logging/manualActionRecorder.js`](js/src/logging/manualActionRecorder.js) can capture auto-advanced checklist steps and export them via the CLI `--record-manual-script` flag for deterministic manual-vs-auto parity runs.
 - `ManualActionQueue` now accepts `dsky_entry` actions so scripted runs and future UI flows can log Verb/Noun inputs and macro payloads for AGC integration while keeping the mission log authoritative.
 - `AutopilotRunner` now interprets `dsky_entry` commands, logging Verb/Noun payloads and forwarding them to the manual action recorder so recorded scripts retain AGC macro usage for parity replays and UI prototypes.
+- Manual interaction contract documented in [`docs/ui/manual_actions_reference.md`](docs/ui/manual_actions_reference.md) so the upcoming UI dispatcher, parity tooling, and ingestion notebooks share a single source of truth for queueing checklist acknowledgements, resource deltas, propellant burns, and DSKY macros.
 - Autopilot authoring reference in [`docs/data/autopilot_scripts.md`](docs/data/autopilot_scripts.md) details the CSV/JSON schema, command vocabulary, propulsion metadata, and validation workflow so new burn profiles stay aligned with the simulator and parity harness.
 - Ingestion workflow planning under [`scripts/ingest/`](scripts/ingest/README.md) and [`docs/data/INGESTION_PIPELINE.md`](docs/data/INGESTION_PIPELINE.md) now documents how future dataset updates move from annotated sources into the CSV/JSON packs, including notebook sequencing, validation checkpoints, and automation hooks.
 - Shared Python helpers under [`scripts/ingest/ingestlib/`](scripts/ingest/ingestlib) expose GET utilities, typed dataset loaders, validation routines, and provenance table builders so notebooks and future automation reuse a single source of truth.
@@ -80,6 +81,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/ui/component_architecture.md`](docs/ui/component_architecture.md) – Component tree, frame ingestion pipeline, tile workspace behavior, and accessibility hooks for the web/N64 UI builds.
 - [`docs/ui/view_data_bindings.md`](docs/ui/view_data_bindings.md) – Detailed data-binding catalog covering the Always-On HUD, Navigation, Controls, Systems, and Tile Mode widgets so implementation stays anchored to mission truth.
 - [`docs/ui/audio_cue_taxonomy.md`](docs/ui/audio_cue_taxonomy.md) – Cue categories, priority routing, dataset integration, and asset specs for the mission audio pipeline.
+- [`docs/ui/manual_actions_reference.md`](docs/ui/manual_actions_reference.md) – Runtime contract for enqueuing manual checklist acknowledgements, resource deltas, propellant burns, and DSKY macros from the UI or parity tooling.
 - [`docs/scoring/commander_rating.md`](docs/scoring/commander_rating.md) – Commander rating model, telemetry inputs, and weighting used by the simulation score system.
 
 ## Contribution Notes

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -65,6 +65,7 @@ Each event has a window, manual inputs, autopilot scripts, telemetry, and failur
 - **Physics:** Patched-conic two-body model, 20 Hz fixed simulation, RK2/RK4 integration, analytic drag during entry.
 - **Attitude & RCS loops:** PD controllers with pulse quantization and PTC maintenance.
 - **Resources:** Fuel cell power tied to cryogenic states, CO₂ accumulation, and comms windows governing PAD delivery.
+- **Manual input loop:** `ManualActionQueue` mediates checklist acknowledgements, resource deltas, propellant burns, and DSKY macros for parity with automated runs; the UI contract lives in [`docs/ui/manual_actions_reference.md`](ui/manual_actions_reference.md) so future front-ends dispatch deterministic actions against the same schema.
 
 ## 7. N64 Implementation Plan
 - **Tech stack:** libdragon, 320×240 at 30 fps, wireframe rendering, ADPCM audio.

--- a/docs/ui/manual_actions_reference.md
+++ b/docs/ui/manual_actions_reference.md
@@ -1,0 +1,46 @@
+# Manual Interaction & Action Queue Contract
+
+The presentation layer drives manual checklist acknowledgements, resource tweaks, and DSKY inputs through the deterministic `ManualActionQueue`. This reference documents the runtime contract so UI components, ingestion tooling, and regression harnesses schedule actions consistently with the simulator’s expectations.
+
+## Execution Flow
+
+1. The simulation context instantiates `ManualActionQueue` with pointers to the checklist manager and resource system whenever manual scripts are loaded or UI layers inject actions at runtime.【F:js/src/sim/simulationContext.js†L25-L143】
+2. Actions are sorted by GET and evaluated every simulation tick. The queue tracks success, failure, and retry counts while logging each execution for post-run analysis.【F:js/src/sim/manualActionQueue.js†L16-L167】
+3. Successful actions mutate mission state (acknowledging checklist steps, applying resource deltas, logging DSKY macros) and append entries to the queue’s history buffer so UI tooling can surface deterministic feedback to the player.【F:js/src/sim/manualActionQueue.js†L171-L317】
+4. Optional retry windows let the UI enqueue steps slightly ahead of an event’s activation. The queue automatically defers execution until prerequisites resolve or the retry window closes.【F:js/src/sim/manualActionQueue.js†L101-L333】
+
+The `ManualActionRecorder` mirrors this pipeline by capturing auto-driven steps and DSKY macros, grouping them into the same action schema so parity runs and UI playback can reuse the data.【F:js/src/logging/manualActionRecorder.js†L12-L409】
+
+## Action Schema
+
+Each queue entry is a JSON object with a `type`, GET timestamp (`get` / `get_seconds`), optional identifier, and optional retry window. The queue normalizes field aliases (e.g., `tank` vs. `tank_key`) so UI code can follow the authoring conventions already used by manual scripts.【F:js/src/sim/manualActionQueue.js†L336-L605】 Key action types:
+
+- **`checklist_ack`** – Acknowledge one or more pending checklist steps for an active event. Requires `event_id`; supports `count`, `actor`, `note`, and retry windows when the step may not yet be available.【F:js/src/sim/manualActionQueue.js†L360-L373】【F:js/src/sim/manualActionQueue.js†L171-L217】
+- **`resource_delta`** – Apply an arbitrary effect payload (matching event success/failure JSON) to the resource model. Useful for scripted load sheds, cryo adjustments, or telemetry overrides.【F:js/src/sim/manualActionQueue.js†L220-L242】【F:js/src/sim/manualActionQueue.js†L375-L381】
+- **`propellant_burn`** – Subtract propellant mass from a named tank (`csm_rcs`, `lm_descent`, etc.). Pounds are converted automatically; failures can be retried if the tank is momentarily unavailable.【F:js/src/sim/manualActionQueue.js†L244-L268】【F:js/src/sim/manualActionQueue.js†L382-L397】
+- **`dsky_entry`** – Log a DSKY macro or verb/noun sequence along with optional register contents or keypress sequences. Entries always emit a mission log payload so UI panes and parity harnesses observe identical AGC inputs.【F:js/src/sim/manualActionQueue.js†L270-L317】【F:js/src/sim/manualActionQueue.js†L398-L426】
+
+Refer to [`docs/data/manual_scripts/README.md`](../data/manual_scripts/README.md) for authoring examples. UI dispatchers can reuse the same JSON without additional wrapping.
+
+## Scheduling & Retry Guidance
+
+- **Immediate actions:** Use the current GET (or add a small offset ≤ one tick) when dispatching player interactions. The queue processes all ready actions before advancing the simulation clock, guaranteeing deterministic outcomes even when several steps trigger on the same tick.【F:js/src/sim/manualActionQueue.js†L84-L133】
+- **Retry windows:** For checklist buttons that may be pressed before an event arms, attach `retry_window_seconds` so the queue retries until the window closes. The action fails only when the retry window expires without prerequisites resolving.【F:js/src/sim/manualActionQueue.js†L101-L205】【F:js/src/sim/manualActionQueue.js†L319-L333】
+- **Sequencing:** When enqueuing multiple actions for the same GET (e.g., DSKY macro then checklist acknowledgement), set deterministic IDs so the queue can maintain insertion order via its internal sort (`internalId`).【F:js/src/sim/manualActionQueue.js†L76-L82】
+- **Metrics & History:** Call `manualActionQueue.stats()` for HUD telemetry (pending vs. executed counts, acknowledgements, etc.) and `historySnapshot()` to feed timeline widgets or debugging overlays.【F:js/src/sim/manualActionQueue.js†L135-L151】
+
+## UI Integration Points
+
+- **Action dispatcher:** Wrap `manualActionQueue.addAction()` in a UI service so panel toggles, DSKY macros, and checklist buttons enqueue normalized actions. The dispatcher should attach `actor` identifiers (`CMP`, `CDR`, `UI`) to preserve crew attribution inside the mission log.【F:js/src/sim/manualActionQueue.js†L68-L121】【F:js/src/sim/manualActionQueue.js†L189-L217】
+- **Recorder bridge:** When UI interactions occur, forward the same metadata to `ManualActionRecorder` so parity scripts and replay exports capture user-driven steps alongside the queue execution.【F:js/src/logging/manualActionRecorder.js†L32-L409】
+- **Error surfacing:** Queue failures return reasons (`event_inactive`, `propellant_unavailable`, etc.) which the UI can surface via console toast or checklist tooltips by inspecting the latest history entry.【F:js/src/sim/manualActionQueue.js†L113-L205】
+- **Persistence:** Manual action recordings include grouped checklist acknowledgements and DSKY entries with formatted GET labels. Exporting recorder output yields a ready-to-run script for regression harnesses or tutorial playback.【F:js/src/logging/manualActionRecorder.js†L189-L220】【F:js/src/logging/manualActionRecorder.js†L236-L409】
+
+## Recommended UI Hooks
+
+1. **Checklist lane:** When the player acknowledges a step, enqueue a `checklist_ack` action with the current GET and actor tag, then optimistically mark the step complete while listening for queue failure feedback.
+2. **Panel toggles affecting resources:** For actions that toggle breakers or pumps outside of scripted effects, enqueue a `resource_delta` describing the expected change so the deterministic resource model aligns with the player’s intent.
+3. **DSKY macro buttons:** Bind macros to `dsky_entry` actions pre-filled with registers and sequence lists drawn from [`docs/ui/dsky_reference.md`](dsky_reference.md). Display queue status (pending/executed) in the Controls view to reinforce deterministic AGC inputs.
+4. **Parity tooling:** Offer a developer toggle that streams recorder output to disk, enabling rapid creation of manual scripts that mirror UI sessions and can be replayed via `npm run parity`.
+
+Aligning UI dispatch logic with this contract keeps manual interactions deterministic, preserves parity between auto and manual runs, and readies the mission data for both the browser prototype and the future N64 build.


### PR DESCRIPTION
## Summary
- add a manual interaction contract doc so UI, parity tooling, and ingestion notebooks share the same queue semantics
- reference the new manual-action guide from the project README and high-level plan

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4d9dd38c8323982b55b6220fdeb1