### PR TITLE
Extend ingestion helpers with audio cue parsing and validation

### DIFF
--- a/scripts/ingest/README.md
+++ b/scripts/ingest/README.md
@@ -24,8 +24,8 @@ These notebooks rely on the `ingestlib` helper package for GET parsing, prerequi
 The `ingestlib` Python package now ships with the workspace and consolidates the shared notebook helpers:
 
 - **`ingestlib.time`** – canonical Ground Elapsed Time parsing/formatting helpers that mirror the simulator's expectations.
-- **`ingestlib.records`** – dataclass-backed representations of events, checklists, autopilots, PADs, failures, and the combined `MissionData` container.
-- **`ingestlib.loader`** – CSV/JSON loaders that resolve file paths relative to `docs/data/` and return typed records ready for analysis.
+- **`ingestlib.records`** – dataclass-backed representations of events, checklists, autopilots, PADs, failures, the audio cue catalog, and the combined `MissionData` container.
+- **`ingestlib.loader`** – CSV/JSON loaders that resolve file paths relative to `docs/data/` and return typed records ready for analysis, including the audio routing pack.
 - **`ingestlib.validation`** – reusable structural checks (window ordering, reference resolution, autopilot script health, PAD GET parsing).
 - **`ingestlib.provenance`** – utilities for composing Markdown tables that document row ranges and source citations.
 

--- a/scripts/ingest/ingestlib/__init__.py
+++ b/scripts/ingest/ingestlib/__init__.py
@@ -11,6 +11,10 @@ from .loader import load_mission_data
 from .provenance import ProvenanceBuilder
 from .records import (
     AutopilotRecord,
+    AudioBus,
+    AudioCategory,
+    AudioCue,
+    AudioCuePack,
     ChecklistEntry,
     EventRecord,
     FailureRecord,
@@ -24,6 +28,10 @@ __all__ = [
     "load_mission_data",
     "ProvenanceBuilder",
     "AutopilotRecord",
+    "AudioBus",
+    "AudioCategory",
+    "AudioCue",
+    "AudioCuePack",
     "ChecklistEntry",
     "EventRecord",
     "FailureRecord",

--- a/scripts/ingest/ingestlib/loader.py
+++ b/scripts/ingest/ingestlib/loader.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable, List
 
 from .records import (
     AutopilotRecord,
+    AudioCuePack,
     ChecklistEntry,
     EventRecord,
     FailureRecord,
@@ -24,6 +25,7 @@ _DATA_FILES = {
     "consumables": "consumables.json",
     "communications": "communications_trends.json",
     "thrusters": "thrusters.json",
+    "audio_cues": "audio_cues.json",
 }
 
 
@@ -58,6 +60,10 @@ def load_failures(path: Path) -> List[FailureRecord]:
     return [FailureRecord.from_row(row) for row in _read_csv(path)]
 
 
+def load_audio_cues(path: Path) -> AudioCuePack:
+    return AudioCuePack.from_dict(_read_json(path))
+
+
 def load_mission_data(data_dir: Path) -> MissionData:
     base = Path(data_dir).resolve()
     events = load_events(base / _DATA_FILES["events"])
@@ -69,6 +75,7 @@ def load_mission_data(data_dir: Path) -> MissionData:
     consumables = _read_json(base / _DATA_FILES["consumables"])
     communications = _read_json(base / _DATA_FILES["communications"])
     thrusters = _read_json(base / _DATA_FILES["thrusters"])
+    audio_cues = load_audio_cues(base / _DATA_FILES["audio_cues"])
 
     return MissionData(
         events=events,
@@ -79,6 +86,7 @@ def load_mission_data(data_dir: Path) -> MissionData:
         consumables=consumables,
         communications=communications,
         thrusters=thrusters,
+        audio_cues=audio_cues,
     )
 
 
@@ -94,6 +102,7 @@ __all__ = [
     "load_autopilots",
     "load_pads",
     "load_failures",
+    "load_audio_cues",
     "load_mission_data",
     "available_datasets",
 ]

--- a/scripts/ingest/ingestlib/utils.py
+++ b/scripts/ingest/ingestlib/utils.py
@@ -75,6 +75,41 @@ def safe_float(value: Any) -> Optional[float]:
     return number
 
 
+def safe_int(value: Any) -> Optional[int]:
+    """Convert ``value`` to ``int`` while ignoring blanks."""
+
+    number = safe_float(value)
+    if number is None:
+        return None
+    rounded = round(number)
+    if abs(number - rounded) > 1e-6:
+        raise ValueError(f"Non-integer value: {value!r}")
+    return int(rounded)
+
+
+def safe_bool(value: Any) -> Optional[bool]:
+    """Convert ``value`` to ``bool`` while accepting common string forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        if abs(value) < 1e-6:
+            return False
+        if abs(value - 1) < 1e-6:
+            return True
+    text = clean_string(value)
+    if text is None:
+        return None
+    lowered = text.lower()
+    if lowered in {"true", "t", "1", "yes", "y", "on"}:
+        return True
+    if lowered in {"false", "f", "0", "no", "n", "off"}:
+        return False
+    raise ValueError(f"Invalid boolean value: {value!r}")
+
+
 def iter_non_null(values: Iterable[Any]):
     """Yield non-empty values from ``values``."""
 


### PR DESCRIPTION
## Summary
- add audio cue dataclasses to the ingestion record layer and expose them via the shared package
- load the audio cue catalog through the ingestion loader and surface it from MissionData
- extend the validation sweep with structural checks for buses, categories, cues, and assets while documenting the new coverage

## Testing
- npm test --prefix js


------
https://chatgpt.com/codex/tasks/task_e_68cd862a6b088323b44ca3a1c8994d24