### PR TITLE
Document manual action recorder pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/sim/progression_service.md`](docs/sim/progression_service.md) – Commander profile normalisation, unlock/achievement evaluation, and persistence hooks.
 - [`docs/sim/manual_action_queue.md`](docs/sim/manual_action_queue.md) – Manual queue scheduling, action types, retry semantics, and integration with the checklist, resource, and AGC subsystems.
 - [`docs/logging/mission_log_reference.md`](docs/logging/mission_log_reference.md) – Logger and aggregator architecture reference that keeps CLI, HUD, parity harnesses, and exports aligned on mission log structure.
+- [`docs/logging/manual_action_recorder.md`](docs/logging/manual_action_recorder.md) – Recorder and replay workflow linking auto crew transcripts, manual overrides, and parity harness scripts into shared JSON artefacts.
 - [`docs/ui/manual_actions_reference.md`](docs/ui/manual_actions_reference.md) – Runtime contract for enqueuing manual checklist acknowledgements, resource deltas, propellant burns, and DSKY macros from the UI or parity tooling.
 - [`docs/scoring/commander_rating.md`](docs/scoring/commander_rating.md) – Commander rating model, telemetry inputs, and weighting used by the simulation score system.
 - [`docs/scoring/progression_unlocks.md`](docs/scoring/progression_unlocks.md) – Progression/unlock plan translating score summaries into campaign, challenge, and cosmetic rewards across platforms.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -68,6 +68,7 @@ Each event has a window, manual inputs, autopilot scripts, telemetry, and failur
 - **Attitude & RCS loops:** PD controllers with pulse quantization and PTC maintenance.
 - **Resources:** Fuel cell power tied to cryogenic states, CO₂ accumulation, and comms windows governing PAD delivery.
 - **Manual input loop:** `ManualActionQueue` mediates checklist acknowledgements, resource deltas, propellant burns, and DSKY macros for parity with automated runs (see [`docs/sim/manual_action_queue.md`](sim/manual_action_queue.md)); the UI contract lives in [`docs/ui/manual_actions_reference.md`](ui/manual_actions_reference.md) so future front-ends dispatch deterministic actions against the same schema.
+- **Manual action recorder:** Recording and replay workflow in [`docs/logging/manual_action_recorder.md`](logging/manual_action_recorder.md) keeps auto crew transcripts, manual overrides, and parity harness scripts aligned so CLI runs, UI prototypes, and the N64 build can share deterministic mission slices without bespoke tooling.
 - **Guidance computer bridge:** The AGC runtime and DSKY command bus defined in [`docs/sim/agc_guidance_integration.md`](sim/agc_guidance_integration.md) synchronize PAD-driven macros, autopilot programs, annunciator alarms, and manual entries against the shared `docs/ui/dsky_macros.json` catalog so guidance state remains deterministic across CLI runs, the upcoming UI, and the N64 build.
 
 ## 7. N64 Implementation Plan

--- a/docs/logging/manual_action_recorder.md
+++ b/docs/logging/manual_action_recorder.md
@@ -1,0 +1,93 @@
+# Manual Action Recorder & Replay Pipeline
+
+The manual action recorder captures every checklist acknowledgement and
+DSKY macro executed during a run so the simulator can replay the same
+mission slice deterministically in parity tests, UI prototypes, and
+future training modes. It complements the manual action queue data
+contract and the mission log architecture by exporting the exact actions
+that the auto crew performed (or that a tester entered manually) as a
+JSON script ready to feed back into the simulation.
+
+## Recorder Instrumentation
+
+`ManualActionRecorder` tracks two streams of inputs—checklist
+acknowledgements and DSKY entries—while keeping roll-up metrics for
+reporting and regression diffs.【F:js/src/logging/manualActionRecorder.js†L5-L221】
+The recorder exposes lightweight `recordChecklistAck()` and
+`recordDskyEntry()` helpers so subsystems can append GET-stamped entries
+without knowing about the eventual export format.
+
+The recorder is wired into the simulation context at construction time,
+allowing the checklist manager and autopilot runner to inject
+observations as soon as they happen.【F:js/src/sim/simulationContext.js†L57-L120】
+- The checklist manager calls `recordChecklistAck()` whenever a step is
+  marked complete, capturing the event ID, checklist ID, step number,
+  actor, GET timestamp, and optional note used for parity diagnostics.【F:js/src/sim/checklistManager.js†L326-L344】
+- The autopilot runner calls `recordDskyEntry()` for every scripted AGC
+  command so replayed runs can mirror Verb/Noun pairs, registers, and key
+  sequences exactly—even when automation triggered the macro.【F:js/src/sim/autopilotRunner.js†L432-L504】
+
+Because the recorder sits beside the logger, audio binder, and HUD
+wiring inside `createSimulationContext()`, any new subsystem can opt into
+recording without changing CLI plumbing. Passing a recorder instance is
+purely optional, enabling lightweight headless or regression contexts
+that do not need manual scripts.【F:js/src/sim/simulationContext.js†L40-L120】
+
+## Script Assembly & Metrics
+
+During a run the recorder accumulates raw entries and tallies aggregate
+metrics (auto vs. manual counts, per-event totals). When callers request
+`buildScriptActions()` or `toJSON()`, the recorder:
+
+1. Filters entries when `includeAutoActionsOnly` is enabled (default) so
+   parity runs replay only the deterministic auto crew actions.
+2. Sorts checklist acknowledgements by GET and event, grouping steps that
+   fired within the same 1/20-second tick so a cluster of auto advances
+   becomes a single `checklist_ack` action with a `count` field.
+3. Converts DSKY entries into deterministic `dsky_entry` actions that
+   preserve macro IDs, Verb/Noun labels, register values, and keypress
+   sequences.
+4. Merges both streams, sorts them chronologically, and emits metadata
+   summarising how many actions were recorded, when the script was
+   generated, and which actor label the replay should attribute to the
+   actions.【F:js/src/logging/manualActionRecorder.js†L123-L221】
+
+The resulting JSON matches the manual action script contract documented
+under `docs/data/manual_scripts/`, so exported scripts can be replayed
+alongside handcrafted scenarios or ingestion outputs without additional
+normalisation.
+
+## CLI Workflow
+
+The CLI entrypoint enables the recorder whenever the user passes
+`--record-manual-script <file>`. `index.js` constructs the recorder,
+threads it into the simulation context, and, once the run completes,
+serialises the aggregated actions to disk with human-readable formatting.
+The CLI prints a short summary so testers know how many actions were
+captured and where the JSON landed.【F:js/src/index.js†L28-L116】
+
+During the same session testers can supply `--manual-script <file>` to
+load a previously recorded script. The simulation context will hydrate a
+`ManualActionQueue` from the file and replay the scripted actions instead
+of auto-advancing checklist steps, guaranteeing the manual run follows
+the same sequence that the recorder captured earlier.【F:js/src/sim/simulationContext.js†L103-L120】
+
+## Parity Harness Integration
+
+`npm run parity` invokes the recorder automatically. The harness runs an
+auto-advance pass with the recorder attached, converts the captured
+actions into a script, then replays those actions through a second run
+with manual advancement disabled. Finally it compares summaries, logs,
+and optional progression profiles to flag any divergence. The parity
+report includes the recorder statistics and the generated action list so
+regression diffs have concrete artefacts to inspect.【F:js/src/tools/runParityCheck.js†L84-L193】
+
+## Future UI & Analytics Hooks
+
+Because the recorder emits actor labels, optional notes, and per-event
+counts, future UI work can surface “auto vs. manual” breakdowns in HUD
+panes or commander scorecards without reprocessing mission logs. Replay
+scripts also allow manual test cases—such as alternate PADs or fault
+injections—to be shared between the CLI, browser prototype, and eventual
+N64 build while remaining faithful to the Apollo procedures captured in
+the mission datasets.


### PR DESCRIPTION
## Summary
- add a dedicated manual action recorder and replay pipeline reference under docs/logging
- link the new documentation from the project plan and the README documentation map so future work can find it easily

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ceef92f4d48323869398cee5a01133