### PR TITLE
Document N64 asset pack workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - Rendezvous and docking overlay specification in [`docs/ui/rendezvous_overlay.md`](docs/ui/rendezvous_overlay.md) defines activation triggers, layout regions, telemetry bindings, and accessibility hooks so the Navigation and Controls panes can present authentic braking gates, docking reticles, and RCS budget cues in lockstep with Milestones M2 and M3.
 - Entry corridor overlay blueprint in [`docs/ui/entry_overlay.md`](docs/ui/entry_overlay.md) maps corridor bands, blackout handling, recovery timelines, PAD integrations, and accessibility behaviours so the Navigation and Systems panes can surface deterministic entry telemetry during the TEI→splashdown finale.
 - Milestone M4 N64 port plan in [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) maps the libdragon architecture, rendering/audio budgets, input scheme, and asset pipeline for the hardware build.
+- N64 ROM asset pipeline blueprint in [`docs/n64/asset_pipeline.md`](docs/n64/asset_pipeline.md) details dataset packing, audio conversion, build automation, and parity validation ahead of the libdragon port.
 - Milestone M5 content integration roadmap in [`docs/milestones/M5_CONTENT_PASS.md`](docs/milestones/M5_CONTENT_PASS.md) itemizes the remaining dataset ingestion work, contingency branches, and ingestion tooling required for the full mission graph.
 - Milestone M6 fidelity pass outline in [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) defines calibration targets for timelines, propulsion, resources, and communications against Apollo 11 telemetry.
 - Milestone M7 stability plan in [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) details soak-testing strategy, fault injection coverage, and automation expectations for release readiness.
@@ -103,6 +104,7 @@ This repository has been reset to develop a real-time Apollo 11 mission simulato
 - [`docs/milestones/M2_GUIDANCE_RCS.md`](docs/milestones/M2_GUIDANCE_RCS.md) – Guidance execution, RCS modelling, and docking gameplay plan.
 - [`docs/milestones/M3_UI_AUDIO.md`](docs/milestones/M3_UI_AUDIO.md) – UI, HUD, audio telemetry, and accessibility planning for the prototype and N64 targets.
 - [`docs/milestones/M4_N64_PORT.md`](docs/milestones/M4_N64_PORT.md) – N64 port architecture, performance validation plan, and Controller Pak integration roadmap.
+- [`docs/n64/asset_pipeline.md`](docs/n64/asset_pipeline.md) – Binary pack formats, audio conversion steps, and ROM build workflow for the Nintendo 64 port.
 - [`docs/milestones/M5_CONTENT_PASS.md`](docs/milestones/M5_CONTENT_PASS.md) – Complete mission dataset integration, contingency coverage, and ingest tooling roadmap.
 - [`docs/milestones/M6_FIDELITY_PASS.md`](docs/milestones/M6_FIDELITY_PASS.md) – Calibration plan for timelines, resources, and communications fidelity.
 - [`docs/milestones/M7_STABILITY_FAULTS.md`](docs/milestones/M7_STABILITY_FAULTS.md) – Stability, fault injection, soak testing, and automation strategy.

--- a/docs/milestones/M4_N64_PORT.md
+++ b/docs/milestones/M4_N64_PORT.md
@@ -73,6 +73,7 @@ Pak persistence for user settings.
 ## Asset & Build Pipeline
 - **Tools:** Add `tools/` scripts (Python 3) for asset packing, ADPCM conversion (using `audioconv64` or ffmpeg wrappers), and ROM
   manifest generation. Provide Makefile targets for `make pack-assets`, `make rom-debug`, and `make rom-release`.
+- **Reference:** Follow the pack formats, audio workflow, and manifest contract outlined in [`docs/n64/asset_pipeline.md`](../n64/asset_pipeline.md) when authoring the tooling.
 - **Continuous integration:** Set up headless emulator runs (cen64 or ares) to boot the ROM, execute a scripted translunar slice,
   and diff deterministic logs against golden outputs.
 - **Versioning:** Embed mission dataset hashes and Git revision metadata into the ROM splash screen for provenance tracking.

--- a/docs/n64/asset_pipeline.md
+++ b/docs/n64/asset_pipeline.md
@@ -1,0 +1,87 @@
+# N64 Asset & Build Pipeline
+
+This guide expands Milestone M4 by describing how the browser-first datasets convert into ROM-ready bundles for the libdragon build. The intent is to reuse the CSV/JSON packs maintained for the JS prototype while producing compact binaries, audio assets, and manifests that the Nintendo 64 runtime can stream efficiently.
+
+## Goals
+- Keep the N64 assets byte-for-byte traceable back to the research datasets under `docs/data/` and the UI definition bundles in `docs/ui/`.
+- Produce deterministic binary packs so simulation parity checks can diff JS and N64 runs using shared hashes.
+- Budget ROM and RAM consumption ahead of time, avoiding last-minute compromises when the renderer, audio pipeline, or logging buffers expand.
+- Share tooling between notebook-driven ingestion (`scripts/ingest/`) and the ROM build so an updated dataset flows through validation, packing, and parity checks with minimal manual intervention.
+
+## Source Data & Versioning
+1. **Historical datasets** – `events.csv`, `checklists.csv`, `pads.csv`, `autopilots/`, `failures.csv`, `communications_trends.json`, and the consumables baseline feed the mission timeline, automation, and resource systems.
+2. **UI definitions** – `docs/ui/checklists.json`, `panels.json`, `dsky_macros.json`, `workspaces.json`, and `hud_layout.md` inform layout metadata, checklist highlighting, and workspace presets required by Tile Mode.
+3. **Audio catalog** – `docs/data/audio_cues.json` plus cue-channel bindings referenced by mission data determine which ADPCM assets must be present in ROM.
+4. **Profile/scoring hooks** – `docs/sim/score_system.md` and `docs/sim/progression_service.md` drive commander rating thresholds and unlock metadata that must persist across runs.
+
+For traceability the packer writes a `manifest.json` alongside each ROM build capturing:
+- Source dataset revision hashes (Git commit + SHA256 per file).
+- Tooling version (Git hash of `tools/pack_n64_assets.py` and libdragon revision).
+- Build options (e.g., stripped vs. debug logging buffers, audio quality tier).
+
+The N64 runtime displays the manifest hash on the splash screen and stores it inside Controller Pak logs to simplify QA triage.
+
+## Binary Pack Layout
+All binary blobs adopt a shared little-endian header: `struct PackHeader { char magic[4]; uint16_t version; uint16_t entryCount; uint32_t tableOffset; uint32_t payloadOffset; }`. The `magic` tag identifies the pack (e.g., `"MTIM"` for mission timeline). Tables contain fixed-width records so the loader can index without heap churn.
+
+### Mission Timeline (`mission_timeline.bin`)
+- **Table fields:** `event_id`, `window_open_s`, `window_close_s`, `autopilot_id`, `checklist_id`, `flags_required`, `flags_set`, `failure_id`, `audio_cue_id`.
+- **Payload:** variable-length prerequisite arrays and PAD references stored as offsets into a string pool.
+- **Notes:** Pre-computed seconds-from-launch values avoid parsing GET strings during play. PAD payloads convert to fixed-point for fast DSKY pre-fill.
+
+### Checklist Pack (`checklists.bin`)
+- **Table fields:** `checklist_id`, `phase`, `role`, `nominal_get_s`, `step_count`, `first_step_index`.
+- **Step table:** contiguous `CheckStep` structures with `panel_id`, `control_mask`, `dsky_macro_id`, tolerance fields, and highlight metadata for HUD overlays.
+- **Notes:** Control masks map directly to the switch-state bitfields described in [`docs/ui/panels.json`](../ui/panels.json), letting the libdragon UI validate toggles without string comparisons.
+
+### Autopilot Scripts (`autopilots.bin`)
+- **Table fields:** `autopilot_id`, `event_id`, `command_offset`, `command_length`, `expected_delta_v_cmps`, `expected_duration_cs`.
+- **Payload:** concatenated command bytes in the same schema consumed by the JS runner (throttle ramps, RCS pulses, attitude holds) with alignment padding for DMA.
+- **Notes:** The loader hydrates scripts into a ring buffer shared with the simulation loop. Tolerances mirror the PAD metadata so burn verification can reuse the JS logic verbatim.
+
+### Communications & Trends (`telemetry.bin`)
+- **Table fields:** DSN pass windows, signal strength, power delta, and comms cue bindings.
+- **History payload:** compressed (delta-encoded) per-minute power/thermal/propellant histories sized for four-hour UI trends.
+- **Notes:** Enables the Systems view to render the same charts documented in [`docs/ui/performance_telemetry.md`](../ui/performance_telemetry.md) without recalculating on-device.
+
+### Audio Cue Table (`audio.tbl`)
+- **Table fields:** `cue_id`, `category`, `bus`, `cooldown_cs`, `priority`, `asset_offset`, `asset_length`, `loop_flag`.
+- **Notes:** The dispatcher module reads this table during boot and links it to libdragon mixer channels. Asset offsets point into an ADPCM blob described below.
+
+### UI Layout Presets (`ui_workspaces.bin`)
+- **Table fields:** `workspace_id`, `tile_count`, `flags` (e.g., Navigation/Controls/Systems defaults).
+- **Payload:** `Tile` entries with normalized positions/sizes, minimum constraints, and associated component IDs. Tile IDs align with `docs/ui/workspaces.json` to keep parity with the web prototype.
+
+### Profiles & Progression (`profile_defaults.bin`)
+- **Table fields:** `profile_version`, `score_thresholds`, `unlock_flags`, `caption_defaults`, `control_mappings`.
+- **Notes:** Seeded during first boot or when the Controller Pak lacks a valid save. Mirrors the schema referenced in [`docs/sim/progression_service.md`](../sim/progression_service.md).
+
+## Audio Conversion Workflow
+1. Export source WAV/FLAC files into `_input/audio/` with metadata (cue ID, loop points, gain recommendations) in `audio_manifest.csv`.
+2. Run `tools/pack_n64_assets.py --audio` to:
+   - Normalize to mono, 22.05 kHz using ffmpeg.
+   - Apply cue-specific gain adjustments.
+   - Convert to libdragon ADPCM via `audioconv64`, capturing loop samples when applicable.
+   - Update `audio.tbl` with offsets and durations while verifying cooldown/priority constraints from `audio_cues.json`.
+3. Inspect the generated `audio_report.txt` summarizing cumulative ROM usage per bus, peak concurrent channel counts, and cues trimmed due to budget limits.
+
+## Build Workflow
+1. **Prepare datasets:** Execute the ingestion notebooks (`docs/data/INGESTION_PIPELINE.md`) and run `npm run validate:data` followed by the parity harness to ensure JS and datasets remain healthy.
+2. **Pack assets:** `make pack-assets` invokes `tools/pack_n64_assets.py` which emits the binary packs into `n64/assets/` and refreshes the manifest. The tool accepts `--dataset-dir`, `--ui-dir`, `--audio-dir`, and `--profile-dir` overrides for automation.
+3. **Compile ROMs:**
+   - `make rom-debug` links against libdragon with asserts, verbose logging, and USB debug enabled. Packs copy verbatim from `n64/assets/`.
+   - `make rom-release` strips debug logs, compresses the mission timeline using LZ4 (optional), and enforces ROM size budgets (target <32 MB).
+4. **Publish artefacts:** Generated ROMs land under `_build/rom/`. Manifest and log snapshots accompany each ROM for archival.
+
+## Validation & Parity Checks
+- **Pack integrity:** The packer writes CRC32 per blob and a global SHA256 recorded inside `manifest.json`. The ROM verifies CRCs at boot, falling back to a safe mode when validation fails.
+- **Cross-build parity:** A CLI utility `tools/compare_packs.py` diff-checks the packed binaries against the JS datasets (e.g., step counts, PAD parameters). Run this during CI alongside the JS regression suite.
+- **Runtime parity:** Nightly jobs boot the debug ROM in cen64/ares, run scripted segments (`launch → MCC-2`, `LOI-1`, `TEI`), and compare deterministic logs against JS exports (`npm run export:ui-frames`). Divergence flags potential packing or fixed-point conversion bugs early.
+- **Audio QA:** The audio report surfaces cues dropped due to ROM limits; reviewers update `audio_cues.json` or adjust loop parameters accordingly before merging.
+
+## Next Steps
+- Implement `tools/pack_n64_assets.py` with modular writers for each blob described above, sharing schema definitions with the JS validator to prevent drift.
+- Add documentation for the runtime loaders in `n64/src/` once implementation begins, referencing the pack layouts and manifest contract defined here.
+- Extend CI scripts to call `make pack-assets` before ROM builds, archiving manifests and pack reports for milestone sign-off.
+
+Coordinating the ROM asset pipeline now ensures the Milestone M4 port inherits the simulator’s deterministic behaviour while respecting the Nintendo 64’s storage and memory constraints.

--- a/n64/README.md
+++ b/n64/README.md
@@ -6,6 +6,7 @@ Detailed milestone planning lives in [`../docs/milestones/M4_N64_PORT.md`](../do
 Key preparation tasks:
 
 - Define data formats that the fixed-step engine can load efficiently from cartridge or ROM, reusing the CSV schemas produced during Milestone M0 (see [`../docs/milestones/M0_DATA_INGESTION.md`](../docs/milestones/M0_DATA_INGESTION.md)).
+- Follow the ROM asset pipeline detailed in [`../docs/n64/asset_pipeline.md`](../docs/n64/asset_pipeline.md) when packing mission data, UI definitions, audio cues, and profile defaults for libdragon builds.
 - Outline rendering constraints for wireframe/line-based scenes and HUD overlays.
 - Mirror the UI/HUD and audio telemetry plan captured in [`../docs/milestones/M3_UI_AUDIO.md`](../docs/milestones/M3_UI_AUDIO.md) while budgeting for 320×240 output, libdragon audio DMA, and Controller Pak storage of accessibility toggles.
 - Plan controller mappings, save infrastructure, and performance budgets as captured in the project plan and informed by the scheduler/loop specification for Milestone M1 ([`../docs/milestones/M1_CORE_SYSTEMS.md`](../docs/milestones/M1_CORE_SYSTEMS.md)).


### PR DESCRIPTION
## Summary
- add a Nintendo 64 asset pipeline blueprint covering binary pack layouts, audio conversion, build flow, and validation hooks
- reference the new plan from the root README, milestone M4 document, and n64 workspace primer so the port effort stays aligned

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d08e0206cc8323a5cdb311ff283bf7