### PR TITLE
Add docking context scaffolding and RCS usage hooks

### DIFF
--- a/js/src/sim/dockingContext.js
+++ b/js/src/sim/dockingContext.js
@@ -1,0 +1,644 @@
+import { formatGET } from '../utils/time.js';
+
+const DEFAULT_OPTIONS = {
+  dutyCycleWindowSeconds: 60,
+};
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+function coerceNumber(value, fallback = null) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function normalizeId(value) {
+  if (!value) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed ? trimmed : null;
+}
+
+export class DockingContext {
+  constructor({
+    config = null,
+    resourceSystem = null,
+    rcsController = null,
+    thrusterConfig = null,
+    logger = null,
+    options = null,
+  } = {}) {
+    this.logger = logger ?? null;
+    this.options = {
+      ...DEFAULT_OPTIONS,
+      ...(options ?? {}),
+    };
+
+    const windowSeconds = Number(this.options.dutyCycleWindowSeconds);
+    this.dutyCycleWindowSeconds = Number.isFinite(windowSeconds) && windowSeconds > 0
+      ? windowSeconds
+      : DEFAULT_OPTIONS.dutyCycleWindowSeconds;
+
+    this.resourceSystem = resourceSystem ?? null;
+    this.rcsController = rcsController ?? null;
+
+    this.config = this.#normalizeConfig(config);
+    this.quadCatalog = this.#buildQuadCatalog(thrusterConfig);
+
+    this.gateState = new Map();
+    this.lastSnapshot = null;
+    this.lastUpdateSeconds = 0;
+
+    this.rcsDutyState = new Map();
+
+    this.unsubscribeRcs = null;
+    if (this.rcsController && typeof this.rcsController.registerUsageListener === 'function') {
+      this.unsubscribeRcs = this.rcsController.registerUsageListener((usage) => {
+        try {
+          this.recordRcsUsage(usage);
+        } catch (error) {
+          this.logger?.log(usage?.getSeconds ?? 0, 'DockingContext RCS listener error', {
+            logSource: 'sim',
+            logCategory: 'docking',
+            logSeverity: 'warning',
+            error: error?.message ?? String(error),
+          });
+        }
+      });
+    }
+  }
+
+  dispose() {
+    if (typeof this.unsubscribeRcs === 'function') {
+      this.unsubscribeRcs();
+      this.unsubscribeRcs = null;
+    }
+  }
+
+  update(currentGetSeconds, { scheduler = null } = {}) {
+    if (!this.config) {
+      this.lastSnapshot = null;
+      this.lastUpdateSeconds = currentGetSeconds;
+      return null;
+    }
+
+    const event = scheduler && typeof scheduler.getEventById === 'function'
+      ? scheduler.getEventById(this.config.eventId)
+      : null;
+
+    const progress = this.#computeEventProgress(currentGetSeconds, event);
+    this.#decayDutyEntries(currentGetSeconds);
+
+    const gates = this.#summarizeGates({ currentGetSeconds, progress, event });
+    const activeGateId = this.#selectActiveGateId(gates);
+
+    const rangeMeters = this.#computeRange(progress);
+    const closingRateMps = this.#resolveClosingRate(activeGateId, gates);
+    const predictedContactVelocityMps = this.#resolveContactVelocity();
+
+    const rcs = this.#summarizeRcs(currentGetSeconds);
+
+    const snapshot = {
+      eventId: this.config.eventId,
+      progress,
+      rangeMeters,
+      closingRateMps,
+      lateralRateMps: 0,
+      predictedContactVelocityMps,
+      gates,
+      activeGateId,
+      activeGate: activeGateId,
+      rcs,
+    };
+
+    this.lastSnapshot = snapshot;
+    this.lastUpdateSeconds = currentGetSeconds;
+    return snapshot;
+  }
+
+  snapshot() {
+    if (!this.lastSnapshot) {
+      return null;
+    }
+
+    const gates = Array.isArray(this.lastSnapshot.gates)
+      ? this.lastSnapshot.gates.map((gate) => ({ ...gate }))
+      : [];
+
+    const rcs = this.lastSnapshot.rcs ? {
+      ...this.lastSnapshot.rcs,
+      quads: Array.isArray(this.lastSnapshot.rcs.quads)
+        ? this.lastSnapshot.rcs.quads.map((quad) => ({ ...quad }))
+        : undefined,
+      propellantKgRemaining: this.lastSnapshot.rcs.propellantKgRemaining
+        ? { ...this.lastSnapshot.rcs.propellantKgRemaining }
+        : undefined,
+      propellantKgBudget: this.lastSnapshot.rcs.propellantKgBudget
+        ? { ...this.lastSnapshot.rcs.propellantKgBudget }
+        : undefined,
+    } : null;
+
+    return {
+      ...this.lastSnapshot,
+      gates,
+      rcs,
+    };
+  }
+
+  stats() {
+    if (!this.lastSnapshot) {
+      return null;
+    }
+    return {
+      lastUpdateSeconds: this.lastUpdateSeconds,
+      activeGateId: this.lastSnapshot.activeGateId ?? null,
+      progress: this.lastSnapshot.progress ?? null,
+      gateStatuses: Array.isArray(this.lastSnapshot.gates)
+        ? this.lastSnapshot.gates.map((gate) => ({ id: gate.id, status: gate.status }))
+        : [],
+    };
+  }
+
+  recordRcsUsage({ thrusters = null, getSeconds = null } = {}) {
+    if (!Array.isArray(thrusters) || thrusters.length === 0) {
+      return;
+    }
+
+    const timestamp = Number(getSeconds);
+    const targetSeconds = Number.isFinite(timestamp) ? timestamp : this.lastUpdateSeconds;
+
+    for (const usage of thrusters) {
+      if (!usage || typeof usage !== 'object') {
+        continue;
+      }
+      const clusterId = normalizeId(usage.clusterId ?? usage.cluster_id ?? null);
+      if (!clusterId) {
+        continue;
+      }
+      const entry = this.#decayDutyEntry(clusterId, targetSeconds);
+      const durationSeconds = coerceNumber(usage.durationSeconds ?? usage.duration_seconds, 0);
+      const massKg = coerceNumber(usage.massKg ?? usage.mass_kg, 0);
+      const pulses = coerceNumber(usage.pulses, 0);
+
+      if (Number.isFinite(durationSeconds) && durationSeconds > 0 && Number.isFinite(pulses) && pulses > 0) {
+        entry.duty += (durationSeconds * pulses) / this.dutyCycleWindowSeconds;
+      } else if (Number.isFinite(durationSeconds) && durationSeconds > 0) {
+        entry.duty += durationSeconds / this.dutyCycleWindowSeconds;
+      }
+      if (Number.isFinite(massKg) && massKg > 0) {
+        entry.massWindowKg += massKg;
+      }
+      entry.lastUsageSeconds = targetSeconds;
+      this.rcsDutyState.set(clusterId, entry);
+    }
+  }
+
+  #summarizeGates({ currentGetSeconds, progress, event }) {
+    if (!Array.isArray(this.config?.gates)) {
+      return [];
+    }
+
+    const openSeconds = coerceNumber(
+      event?.getOpenSeconds
+        ?? event?.get_open_seconds
+        ?? event?.openSeconds
+        ?? event?.opensAtSeconds
+        ?? event?.opens_at_seconds,
+      null,
+    );
+    const closeSeconds = coerceNumber(
+      event?.getCloseSeconds
+        ?? event?.get_close_seconds
+        ?? event?.closeSeconds
+        ?? event?.closesAtSeconds
+        ?? event?.closes_at_seconds,
+      null,
+    );
+    const activationSeconds = coerceNumber(event?.activationTimeSeconds ?? event?.activation_time_seconds, null);
+    const completionSeconds = coerceNumber(event?.completionTimeSeconds ?? event?.completion_time_seconds, null);
+
+    const summaries = [];
+    for (const gate of this.config.gates) {
+      const state = this.#updateGateState({
+        gate,
+        progress,
+        currentGetSeconds,
+        activationSeconds,
+        completionSeconds,
+      });
+
+      const deadlineSeconds = this.#computeGateDeadline(gate, { openSeconds, closeSeconds, completionSeconds, state });
+      const deadlineGet = Number.isFinite(deadlineSeconds) ? formatGET(Math.round(deadlineSeconds)) : null;
+      const timeRemainingSeconds = Number.isFinite(deadlineSeconds)
+        ? deadlineSeconds - currentGetSeconds
+        : null;
+      const overdue = Number.isFinite(timeRemainingSeconds) ? timeRemainingSeconds < 0 : false;
+
+      const summary = {
+        id: gate.id,
+        label: gate.label,
+        rangeMeters: gate.rangeMeters,
+        targetRateMps: gate.targetRateMps,
+        tolerance: gate.tolerance,
+        activationProgress: gate.activationProgress,
+        completionProgress: gate.completionProgress,
+        checklistId: gate.checklistId,
+        sources: gate.sources,
+        status: state.status,
+        progress: state.gateProgress,
+        activatedAtSeconds: state.activatedAtSeconds,
+        completedAtSeconds: state.completedAtSeconds,
+        deadlineSeconds,
+        deadlineGet,
+        timeRemainingSeconds,
+        overdue,
+      };
+
+      summaries.push(summary);
+    }
+
+    return summaries;
+  }
+
+  #selectActiveGateId(gates) {
+    if (!Array.isArray(gates) || gates.length === 0) {
+      return null;
+    }
+
+    for (const gate of gates) {
+      if (gate.status === 'active') {
+        return gate.id;
+      }
+    }
+
+    for (const gate of gates) {
+      if (gate.status !== 'complete') {
+        return gate.id;
+      }
+    }
+
+    return gates[gates.length - 1].id;
+  }
+
+  #computeRange(progress) {
+    if (!this.config) {
+      return null;
+    }
+    const start = coerceNumber(this.config.startRangeMeters, null);
+    const end = coerceNumber(this.config.endRangeMeters, null);
+    if (!(Number.isFinite(start) && Number.isFinite(end))) {
+      return null;
+    }
+    const fraction = clamp(progress ?? 0, 0, 1);
+    return start + (end - start) * fraction;
+  }
+
+  #resolveClosingRate(activeGateId, gates) {
+    if (!Array.isArray(gates) || gates.length === 0) {
+      return null;
+    }
+    if (activeGateId) {
+      const active = gates.find((gate) => gate.id === activeGateId);
+      if (active && Number.isFinite(active.targetRateMps)) {
+        return active.targetRateMps;
+      }
+    }
+    const last = gates[gates.length - 1];
+    return Number.isFinite(last?.targetRateMps) ? last.targetRateMps : null;
+  }
+
+  #resolveContactVelocity() {
+    if (!this.config || !Array.isArray(this.config.gates) || this.config.gates.length === 0) {
+      return null;
+    }
+    const lastGate = this.config.gates[this.config.gates.length - 1];
+    return Number.isFinite(lastGate?.targetRateMps) ? lastGate.targetRateMps : null;
+  }
+
+  #summarizeRcs(currentGetSeconds) {
+    const summary = {};
+
+    const remaining = {};
+    const budget = {};
+
+    const propellantState = this.resourceSystem?.state?.propellant ?? {};
+    for (const [key, value] of Object.entries(propellantState)) {
+      const normalizedKey = this.#normalizePropellantKey(key);
+      const numeric = coerceNumber(value, null);
+      if (normalizedKey && Number.isFinite(numeric)) {
+        remaining[normalizedKey] = numeric;
+      }
+    }
+
+    const propellantBudgets = this.resourceSystem?.budgets?.propellant ?? {};
+    for (const [rawKey, entry] of Object.entries(propellantBudgets)) {
+      const normalizedKey = this.#normalizePropellantKey(rawKey);
+      const initial = coerceNumber(entry?.initial_kg ?? entry?.initialKg, null);
+      if (normalizedKey && Number.isFinite(initial)) {
+        budget[normalizedKey] = initial;
+      }
+    }
+
+    if (Object.keys(remaining).length > 0) {
+      summary.propellantKgRemaining = remaining;
+    }
+    if (Object.keys(budget).length > 0) {
+      summary.propellantKgBudget = budget;
+    }
+
+    if (this.quadCatalog.length > 0) {
+      const quads = [];
+      for (const quad of this.quadCatalog) {
+        const entry = this.#decayDutyEntry(quad.id, currentGetSeconds);
+        const dutyPct = Number.isFinite(entry?.duty)
+          ? clamp(entry.duty * 100, 0, 100)
+          : null;
+        quads.push({
+          id: quad.id,
+          enabled: true,
+          dutyCyclePct: dutyPct,
+        });
+      }
+      summary.quads = quads;
+    }
+
+    return summary;
+  }
+
+  #computeEventProgress(currentGetSeconds, event) {
+    const status = event?.status ?? event?.event_status ?? null;
+
+    if (status === 'complete' || status === 'completed' || status === 'failed') {
+      return 1;
+    }
+
+    if (status === 'active') {
+      const activationSeconds = coerceNumber(
+        event?.activationTimeSeconds ?? event?.activation_time_seconds,
+        null,
+      );
+      const expectedDurationSeconds = coerceNumber(
+        event?.expectedDurationSeconds ?? event?.expected_duration_seconds,
+        null,
+      );
+      if (Number.isFinite(activationSeconds) && Number.isFinite(expectedDurationSeconds) && expectedDurationSeconds > 0) {
+        const elapsed = currentGetSeconds - activationSeconds;
+        return clamp(elapsed / expectedDurationSeconds, 0, 1);
+      }
+    }
+
+    const openSeconds = coerceNumber(
+      event?.getOpenSeconds
+        ?? event?.get_open_seconds
+        ?? event?.openSeconds
+        ?? event?.opensAtSeconds
+        ?? event?.opens_at_seconds,
+      null,
+    );
+    const closeSeconds = coerceNumber(
+      event?.getCloseSeconds
+        ?? event?.get_close_seconds
+        ?? event?.closeSeconds
+        ?? event?.closesAtSeconds
+        ?? event?.closes_at_seconds,
+      null,
+    );
+
+    if (Number.isFinite(openSeconds) && Number.isFinite(closeSeconds) && closeSeconds > openSeconds) {
+      const fraction = (currentGetSeconds - openSeconds) / (closeSeconds - openSeconds);
+      return clamp(fraction, 0, 1);
+    }
+
+    return 0;
+  }
+
+  #updateGateState({ gate, progress, currentGetSeconds, activationSeconds, completionSeconds }) {
+    const state = this.gateState.get(gate.id) ?? {
+      status: 'pending',
+      activatedAtSeconds: null,
+      completedAtSeconds: null,
+      gateProgress: 0,
+    };
+
+    const activation = clamp(coerceNumber(gate.activationProgress, 0), 0, 1);
+    const completion = clamp(coerceNumber(gate.completionProgress, 1), 0, 1);
+    const normalizedProgress = clamp(progress ?? 0, 0, 1);
+
+    let status = 'pending';
+    let activatedAtSeconds = state.activatedAtSeconds;
+    let completedAtSeconds = state.completedAtSeconds;
+    let gateProgress = 0;
+
+    if (normalizedProgress >= completion) {
+      status = 'complete';
+      gateProgress = 1;
+      if (!Number.isFinite(completedAtSeconds)) {
+        completedAtSeconds = Number.isFinite(completionSeconds)
+          ? completionSeconds
+          : currentGetSeconds;
+      }
+      if (!Number.isFinite(activatedAtSeconds)) {
+        activatedAtSeconds = Number.isFinite(activationSeconds)
+          ? activationSeconds
+          : currentGetSeconds;
+      }
+    } else if (normalizedProgress >= activation) {
+      status = 'active';
+      const span = completion - activation;
+      gateProgress = span > 0 ? clamp((normalizedProgress - activation) / span, 0, 1) : 0;
+      if (!Number.isFinite(activatedAtSeconds)) {
+        activatedAtSeconds = Number.isFinite(activationSeconds)
+          ? activationSeconds
+          : currentGetSeconds;
+      }
+    } else {
+      status = 'pending';
+      gateProgress = 0;
+    }
+
+    const nextState = {
+      status,
+      activatedAtSeconds,
+      completedAtSeconds,
+      gateProgress,
+    };
+
+    this.gateState.set(gate.id, nextState);
+    return nextState;
+  }
+
+  #computeGateDeadline(gate, { openSeconds, closeSeconds, completionSeconds, state }) {
+    if (Number.isFinite(state?.completedAtSeconds)) {
+      return state.completedAtSeconds;
+    }
+
+    if (
+      Number.isFinite(openSeconds)
+      && Number.isFinite(closeSeconds)
+      && closeSeconds > openSeconds
+    ) {
+      const fraction = clamp(coerceNumber(gate.completionProgress, 1), 0, 1);
+      return openSeconds + (closeSeconds - openSeconds) * fraction;
+    }
+
+    if (Number.isFinite(completionSeconds)) {
+      return completionSeconds;
+    }
+
+    return null;
+  }
+
+  #normalizeConfig(rawConfig) {
+    if (!rawConfig || typeof rawConfig !== 'object') {
+      return null;
+    }
+
+    const eventId = normalizeId(rawConfig.eventId ?? rawConfig.event_id ?? null);
+    if (!eventId) {
+      return null;
+    }
+
+    const config = {
+      eventId,
+      notes: typeof rawConfig.notes === 'string' ? rawConfig.notes : null,
+      startRangeMeters: coerceNumber(rawConfig.startRangeMeters ?? rawConfig.start_range_meters, null),
+      endRangeMeters: coerceNumber(rawConfig.endRangeMeters ?? rawConfig.end_range_meters, null),
+      version: coerceNumber(rawConfig.version, null),
+      gates: [],
+    };
+
+    const gateEntries = Array.isArray(rawConfig.gates) ? rawConfig.gates : [];
+    for (const rawGate of gateEntries) {
+      const id = normalizeId(rawGate.id ?? rawGate.gateId ?? rawGate.gate_id ?? null);
+      if (!id) {
+        continue;
+      }
+      const gate = {
+        id,
+        label: typeof rawGate.label === 'string' ? rawGate.label : id,
+        rangeMeters: coerceNumber(rawGate.rangeMeters ?? rawGate.range_meters, null),
+        targetRateMps: coerceNumber(rawGate.targetRateMps ?? rawGate.target_rate_mps, null),
+        tolerance: this.#normalizeTolerance(rawGate.tolerance ?? rawGate.tolerance_pct ?? null),
+        activationProgress: coerceNumber(rawGate.activationProgress ?? rawGate.activation_progress, 0),
+        completionProgress: coerceNumber(rawGate.completionProgress ?? rawGate.completion_progress, 1),
+        checklistId: normalizeId(rawGate.checklistId ?? rawGate.checklist_id ?? null),
+        sources: Array.isArray(rawGate.sources) ? rawGate.sources.filter((item) => typeof item === 'string') : null,
+      };
+      config.gates.push(gate);
+    }
+
+    return config;
+  }
+
+  #normalizeTolerance(rawTolerance) {
+    if (!rawTolerance || typeof rawTolerance !== 'object') {
+      return null;
+    }
+    const plus = coerceNumber(rawTolerance.plus ?? rawTolerance.max, null);
+    const minus = coerceNumber(rawTolerance.minus ?? rawTolerance.min, null);
+    if (!Number.isFinite(plus) && !Number.isFinite(minus)) {
+      return null;
+    }
+    const tolerance = {};
+    if (Number.isFinite(plus)) {
+      tolerance.plus = plus;
+    }
+    if (Number.isFinite(minus)) {
+      tolerance.minus = minus;
+    }
+    return tolerance;
+  }
+
+  #buildQuadCatalog(thrusterConfig) {
+    const catalog = [];
+    if (!thrusterConfig || typeof thrusterConfig !== 'object') {
+      return catalog;
+    }
+
+    const craftEntries = Array.isArray(thrusterConfig.craft) ? thrusterConfig.craft : [];
+    for (const craft of craftEntries) {
+      const clusters = craft?.rcs?.clusters;
+      if (!Array.isArray(clusters)) {
+        continue;
+      }
+      for (const cluster of clusters) {
+        const id = normalizeId(cluster?.id);
+        if (!id) {
+          continue;
+        }
+        catalog.push({ id });
+      }
+    }
+    return catalog;
+  }
+
+  #normalizePropellantKey(key) {
+    if (!key) {
+      return null;
+    }
+    const trimmed = String(key).trim();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed.replace(/_kg$/iu, '');
+  }
+
+  #decayDutyEntries(targetSeconds) {
+    const time = Number(targetSeconds);
+    if (!Number.isFinite(time)) {
+      return;
+    }
+    for (const [clusterId] of this.rcsDutyState) {
+      this.#decayDutyEntry(clusterId, time);
+    }
+  }
+
+  #decayDutyEntry(clusterId, targetSeconds) {
+    let entry = this.rcsDutyState.get(clusterId);
+    if (!entry) {
+      entry = {
+        duty: 0,
+        massWindowKg: 0,
+        lastUpdateSeconds: Number.isFinite(targetSeconds) ? targetSeconds : 0,
+        lastUsageSeconds: null,
+      };
+      this.rcsDutyState.set(clusterId, entry);
+      return entry;
+    }
+
+    const now = Number(targetSeconds);
+    if (!Number.isFinite(now)) {
+      return entry;
+    }
+
+    const deltaSeconds = now - (entry.lastUpdateSeconds ?? now);
+    if (Number.isFinite(deltaSeconds) && deltaSeconds > 0) {
+      const decay = Math.exp(-deltaSeconds / this.dutyCycleWindowSeconds);
+      entry.duty *= decay;
+      entry.massWindowKg *= decay;
+      entry.lastUpdateSeconds = now;
+    } else if (!Number.isFinite(entry.lastUpdateSeconds)) {
+      entry.lastUpdateSeconds = now;
+    }
+
+    return entry;
+  }
+}
+

--- a/js/src/sim/simulationContext.js
+++ b/js/src/sim/simulationContext.js
@@ -18,6 +18,7 @@ import { AudioCueBinder } from '../audio/audioCueBinder.js';
 import { AudioDispatcher, NullAudioMixer } from '../audio/audioDispatcher.js';
 import { AgcRuntime } from './agcRuntime.js';
 import { WorkspaceStore } from '../hud/workspaceStore.js';
+import { DockingContext } from './dockingContext.js';
 
 const DEFAULT_OPTIONS = {
   tickRate: 20,
@@ -76,6 +77,14 @@ export async function createSimulationContext({
   });
 
   const rcsController = new RcsController(missionData.thrusters, resourceSystem, logger);
+
+  const dockingContext = new DockingContext({
+    config: missionData.docking,
+    resourceSystem,
+    rcsController,
+    thrusterConfig: missionData.thrusters,
+    logger,
+  });
 
   const agcRuntime = new AgcRuntime({
     logger,
@@ -190,6 +199,7 @@ export async function createSimulationContext({
     missionLogAggregator,
     audioBinder,
     audioDispatcher,
+    docking: dockingContext,
   });
 
   workspaceStore.setTimeProvider(() => simulation?.clock?.getCurrent?.() ?? 0);
@@ -216,6 +226,7 @@ export async function createSimulationContext({
     audioMixer,
     audioCues: missionData.audioCues,
     logger,
+    docking: dockingContext,
     options: {
       dataDir: resolvedDataDir,
       tickRate,

--- a/js/test/dockingContext.test.js
+++ b/js/test/dockingContext.test.js
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DockingContext } from '../src/sim/dockingContext.js';
+import { parseGET, formatGET } from '../src/utils/time.js';
+
+test('DockingContext tracks gate progress and RCS duty cycle', () => {
+  const dockingConfig = {
+    eventId: 'LM_ASCENT_030',
+    startRangeMeters: 500,
+    endRangeMeters: 0,
+    notes: 'Apollo 11 braking gates',
+    gates: [
+      {
+        id: 'GATE_500M',
+        label: '500 m braking gate',
+        rangeMeters: 500,
+        targetRateMps: -2.4,
+        tolerance: { plus: 0.8, minus: 0.4 },
+        activationProgress: 0.0,
+        completionProgress: 0.3,
+        checklistId: 'FP_7-32_RNDZ_DOCK',
+        sources: ['Apollo 11 Flight Plan p. 7-32'],
+      },
+      {
+        id: 'GATE_150M',
+        label: '150 m braking gate',
+        rangeMeters: 150,
+        targetRateMps: -0.9,
+        tolerance: { plus: 0.3, minus: 0.2 },
+        activationProgress: 0.3,
+        completionProgress: 0.7,
+        checklistId: 'FP_7-32_RNDZ_DOCK',
+        sources: ['Apollo 11 Flight Plan p. 7-32'],
+      },
+      {
+        id: 'GATE_CONTACT',
+        label: 'Contact gate',
+        rangeMeters: 0,
+        targetRateMps: -0.2,
+        tolerance: { plus: 0.05, minus: 0.05 },
+        activationProgress: 0.9,
+        completionProgress: 1.0,
+        checklistId: 'FP_7-32_RNDZ_DOCK',
+        sources: ['Apollo 11 Flight Plan p. 7-32'],
+      },
+    ],
+  };
+
+  const resourceSystem = {
+    state: { propellant: { lm_rcs_kg: 110.2, csm_rcs_kg: 280.5 } },
+    budgets: {
+      propellant: {
+        lm_rcs: { initial_kg: 138 },
+        csm_rcs: { initial_kg: 320 },
+      },
+    },
+  };
+
+  const thrusterConfig = {
+    craft: [
+      {
+        id: 'LM',
+        rcs: {
+          clusters: [
+            { id: 'LM_RCS_QUAD_A', thrusters: [] },
+            { id: 'LM_RCS_QUAD_B', thrusters: [] },
+          ],
+        },
+      },
+    ],
+  };
+
+  const docking = new DockingContext({
+    config: dockingConfig,
+    resourceSystem,
+    thrusterConfig,
+  });
+
+  const openSeconds = parseGET('125:40:00');
+  const closeSeconds = parseGET('128:30:00');
+  const activationSeconds = parseGET('125:50:00');
+  const event = {
+    id: 'LM_ASCENT_030',
+    status: 'active',
+    getOpenSeconds: openSeconds,
+    getCloseSeconds: closeSeconds,
+    activationTimeSeconds: activationSeconds,
+    expectedDurationSeconds: 7200,
+  };
+  const scheduler = {
+    getEventById: (id) => (id === 'LM_ASCENT_030' ? event : null),
+  };
+
+  const usageTime = parseGET('126:44:00');
+  docking.recordRcsUsage({
+    getSeconds: usageTime,
+    thrusters: [
+      {
+        id: 'LM_RCS_A1',
+        clusterId: 'LM_RCS_QUAD_A',
+        pulses: 4,
+        durationSeconds: 0.4,
+        massKg: 0.6,
+      },
+    ],
+  });
+
+  const currentGetSeconds = parseGET('126:45:00');
+  docking.update(currentGetSeconds, { scheduler });
+
+  const snapshot = docking.snapshot();
+  assert.ok(snapshot);
+  assert.equal(snapshot.eventId, 'LM_ASCENT_030');
+  assert.equal(snapshot.activeGateId, 'GATE_150M');
+  assert.ok(snapshot.progress > 0.4 && snapshot.progress < 0.7);
+  assert.ok(snapshot.rangeMeters < dockingConfig.startRangeMeters);
+  assert.equal(snapshot.closingRateMps, -0.9);
+  assert.equal(snapshot.predictedContactVelocityMps, -0.2);
+
+  const gate150 = snapshot.gates.find((gate) => gate.id === 'GATE_150M');
+  assert.ok(gate150);
+  assert.equal(gate150.status, 'active');
+  assert.ok(gate150.progress > 0 && gate150.progress <= 1);
+  assert.equal(gate150.deadlineSeconds, openSeconds + (closeSeconds - openSeconds) * 0.7);
+  assert.equal(gate150.deadlineGet, formatGET(gate150.deadlineSeconds));
+
+  const rcs = snapshot.rcs;
+  assert.ok(rcs);
+  assert.equal(rcs.propellantKgRemaining.lm_rcs, 110.2);
+  assert.equal(rcs.propellantKgBudget.lm_rcs, 138);
+  const quadA = rcs.quads.find((quad) => quad.id === 'LM_RCS_QUAD_A');
+  assert.ok(quadA);
+  assert.ok(quadA.dutyCyclePct === null || quadA.dutyCyclePct > 0);
+
+  // Complete the event and ensure gates mark complete.
+  event.status = 'complete';
+  event.completionTimeSeconds = parseGET('127:20:00');
+  docking.update(event.completionTimeSeconds, { scheduler });
+  const finalSnapshot = docking.snapshot();
+  assert.ok(finalSnapshot);
+  assert.equal(finalSnapshot.progress, 1);
+  const contactGate = finalSnapshot.gates.find((gate) => gate.id === 'GATE_CONTACT');
+  assert.ok(contactGate);
+  assert.equal(contactGate.status, 'complete');
+});

--- a/js/test/rcsController.test.js
+++ b/js/test/rcsController.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RcsController } from '../src/sim/rcsController.js';
+
+test('RcsController usage listener receives cluster metrics', () => {
+  const thrusterConfig = {
+    craft: [
+      {
+        id: 'LM',
+        name: 'LM',
+        propellant_tank: 'lm_rcs_kg',
+        rcs: {
+          defaults: {
+            thrust_newtons: 445,
+            isp_seconds: 285,
+            min_impulse_seconds: 0.1,
+          },
+          clusters: [
+            {
+              id: 'LM_RCS_QUAD_A',
+              thrusters: [
+                {
+                  id: 'LM_RCS_A1',
+                  translation_axis: '+X',
+                  torque_axes: ['+yaw'],
+                  thrust_newtons: 445,
+                  isp_seconds: 285,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const resourceSystem = {
+    recordPropellantUsage: () => {},
+  };
+
+  const controller = new RcsController(thrusterConfig, resourceSystem, null, {
+    defaultImpulseSeconds: 0.1,
+  });
+
+  const events = [];
+  const unsubscribe = controller.registerUsageListener((payload) => {
+    events.push(payload);
+  });
+
+  const result = controller.executePulse({
+    craftId: 'LM',
+    axis: '+X',
+    durationSeconds: 0.5,
+    count: 2,
+    getSeconds: 100,
+    autopilotId: 'TEST_AUTOPILOT',
+  });
+
+  assert.ok(result.massKg > 0);
+  assert.equal(result.craftId, 'LM');
+  assert.equal(events.length, 1);
+  const usage = events[0];
+  assert.equal(usage.autopilotId, 'TEST_AUTOPILOT');
+  assert.equal(usage.craftId, 'LM');
+  assert.ok(Array.isArray(usage.thrusters));
+  assert.equal(usage.thrusters.length, 1);
+  const thrusterUsage = usage.thrusters[0];
+  assert.equal(thrusterUsage.clusterId, 'LM_RCS_QUAD_A');
+  assert.ok(thrusterUsage.durationSeconds > 0);
+  assert.ok(thrusterUsage.massKg > 0);
+
+  const stats = controller.stats();
+  assert.ok(stats.usageByCluster);
+  assert.ok(stats.usageByCluster.LM_RCS_QUAD_A > 0);
+
+  unsubscribe();
+});


### PR DESCRIPTION
## Summary
- add a DockingContext that tracks rendezvous gate progress, range, and RCS summaries for HUD consumers
- extend the RcsController with per-cluster usage metrics and an event listener used by the docking context
- wire the docking context into the simulation pipeline and add tests covering docking telemetry and RCS usage notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d184008e1c8323b00b8d38b5bba5d2