### PR TITLE
Integrate failure cascades into JS scheduler

### DIFF
--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -35,6 +35,9 @@ The shared helper package at [`../scripts/ingest/ingestlib/`](../../scripts/inge
   validation workflow.
 - `failures.csv` – Recoverable and hard failure hooks tied to mission logic, including optional
   `audio_cue_warning`/`audio_cue_failure` references for caution and master alarm routing.
+- `failure_cascades.json` – Structured cascade definitions that translate failure taxonomy
+  entries into resource penalties, delta-v adjustments, and optional follow-up event arming so the
+  scheduler can react deterministically when faults latch.
 - `pads.csv` – Uplink cards for burns and corrections.
 - `provenance.md` – Source citations for every record range.
 - `consumables.json` – Baseline power, propellant, and life-support budgets with notes and references to the Mission Operations Report and Flight Plan.

--- a/docs/data/failure_cascades.json
+++ b/docs/data/failure_cascades.json
@@ -1,0 +1,152 @@
+{
+  "FAIL_TLI_PAD_LATE": {
+    "resourceEffects": {
+      "delta_v_margin_mps": -10
+    },
+    "log": {
+      "message": "TLI PAD late: Δv margin reduced by 10 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_TLI_UNDERBURN": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "csm_sps": {
+            "delta_mps": -25
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "TLI underburn increases MCC-1 correction budget by 25 m/s",
+      "severity": "failure"
+    }
+  },
+  "FAIL_MCC1_PAD_MISSED": {
+    "resourceEffects": {
+      "delta_v_margin_mps": -15
+    },
+    "log": {
+      "message": "MCC-1 PAD missed: Δv margin reduced by 15 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_MCC1_SKIPPED": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "csm_sps": {
+            "delta_mps": -25
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "MCC-1 skipped: MCC-2 correction requires an extra 25 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_MCC2_SKIPPED": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "csm_sps": {
+            "delta_mps": -5
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "MCC-2 skipped: downstream correction budget loses 5 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_MCC3_SKIPPED": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "csm_sps": {
+            "delta_mps": -0.9144
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "MCC-3 skipped: MCC-4 trimming margin reduced by 0.9 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_MCC4_SKIPPED": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "csm_sps": {
+            "delta_mps": -5
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "MCC-4 skipped: LOI-1 Δv reserve drops by 5 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_DOI_SKIPPED": {
+    "resourceEffects": {
+      "delta_v": {
+        "stages": {
+          "lm_descent": {
+            "delta_mps": -61
+          }
+        }
+      }
+    },
+    "log": {
+      "message": "DOI skipped: PDI propellant reserve reduced by 61 m/s",
+      "severity": "warning"
+    }
+  },
+  "FAIL_THERMAL_PTC_LATE": {
+    "resourceEffects": {
+      "power_margin_pct": -5,
+      "cryo_boiloff_rate_pct_per_hr": 0.5
+    },
+    "log": {
+      "message": "PTC not established: power margin -5%, boiloff trending up",
+      "severity": "warning"
+    }
+  },
+  "FAIL_THERMAL_PTC_DRIFT": {
+    "resourceEffects": {
+      "power_margin_pct": -3,
+      "cryo_boiloff_rate_pct_per_hr": 0.3
+    },
+    "log": {
+      "message": "PTC drift: power margin -3%, boiloff increasing",
+      "severity": "warning"
+    }
+  },
+  "FAIL_RETURN_PTC_SKIPPED": {
+    "resourceEffects": {
+      "power_margin_pct": -4,
+      "cryo_boiloff_rate_pct_per_hr": 0.3
+    },
+    "log": {
+      "message": "Return PTC skipped: transearth thermal balance deteriorating",
+      "severity": "warning"
+    }
+  },
+  "FAIL_COMM_PASS_MISSED": {
+    "resourceEffects": {
+      "communications": {
+        "missed_passes": 1
+      }
+    },
+    "log": {
+      "message": "Communications pass missed: DSN catch-up required",
+      "severity": "warning"
+    },
+    "repeatable": true
+  }
+}

--- a/docs/milestones/M1_CORE_SYSTEMS.md
+++ b/docs/milestones/M1_CORE_SYSTEMS.md
@@ -90,7 +90,7 @@ The HUD can be console-based during M1—rendered as a simple text grid updated 
 ### Known Gaps Before M1 Completion
 - Manual action scripts now cover checklist overrides and resource deltas, and the CLI can record auto crew acknowledgements into reusable scripts; the parity harness in [`js/src/tools/runParityCheck.js`](../../js/src/tools/runParityCheck.js) replays those recordings, highlights event/resource/autopilot diffs, and now compares event timelines—next steps hook its reports into automated regression gating.
 - Consumable budgets seed the resource model, yet PAD-driven deltas and long-horizon trending analytics still need to be wired into the scheduler for scoring.
-- Failure hooks now capture the taxonomy metadata (classification, penalties, recovery actions) from `failures.csv`, but downstream remedial event arming and cascading penalties still need to be wired into the scheduler.
+- Failure hooks now capture the taxonomy metadata (classification, penalties, recovery actions) from `failures.csv`, and the scheduler consumes `failure_cascades.json` to apply resource penalties and arm recovery events when faults latch. Continue expanding cascade coverage as additional failure modes are ingested.
 - Autopilot runner currently assumes constant mass-flow rates per propulsion system; calibrate against PAD timelines and hook tolerances into the failure taxonomy so underburn/overburn conditions propagate meaningfully.
 - Deterministic log replay/regression tooling is not yet capturing frame-by-frame state, leaving validation to manual CLI runs.
 

--- a/docs/sim/event_scheduler.md
+++ b/docs/sim/event_scheduler.md
@@ -49,6 +49,9 @@ system, and emits autopilot summaries to registered observers, keeping Δv,
 propellant, and PAD analytics synchronized across systems.【F:js/src/sim/eventScheduler.js†L193-L217】
 `Simulation.run()` invokes `scheduler.update()` before resource and HUD refreshes
 so every downstream consumer operates on the latest event state.【F:js/src/sim/simulation.js†L34-L141】
+Failure cascades defined in `docs/data/failure_cascades.json` are consumed via the
+new scheduler hooks, applying dataset-driven resource penalties and optionally
+arming recovery events whenever a mission failure latches.【F:docs/data/failure_cascades.json†L1-L66】【F:js/src/sim/eventScheduler.js†L1-L752】
 
 ## Failure Handling & Tolerance Enforcement
 

--- a/js/src/sim/resourceSystem.js
+++ b/js/src/sim/resourceSystem.js
@@ -66,6 +66,7 @@ const DEFAULT_STATE = {
     cue_channel_on_loss: null,
     next_pass_cue_on_acquire: null,
     next_pass_cue_channel: null,
+    missed_passes: 0,
   },
 };
 

--- a/js/src/sim/simulationContext.js
+++ b/js/src/sim/simulationContext.js
@@ -171,6 +171,7 @@ export async function createSimulationContext({
       autopilotRunner,
       autopilotSummaryHandlers,
       audioBinder,
+      failureCascades: missionData.failureCascades,
     },
   );
 

--- a/js/test/eventScheduler.test.js
+++ b/js/test/eventScheduler.test.js
@@ -1,0 +1,185 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EventScheduler } from '../src/sim/eventScheduler.js';
+import { ResourceSystem } from '../src/sim/resourceSystem.js';
+import { createTestLogger } from './testUtils.js';
+
+describe('EventScheduler failure cascades', () => {
+  it('applies cascade resource effects and arms follow-up events', () => {
+    const logger = createTestLogger();
+    const resourceSystem = new ResourceSystem(logger);
+    const failureCascades = new Map([
+      ['FAIL_TEST', {
+        id: 'FAIL_TEST',
+        resourceEffects: { power_margin_pct: -5 },
+        repeatable: false,
+        applyOnce: false,
+        armEvents: [
+          {
+            eventId: 'RECOVERY_EVENT',
+            allowBeforeWindow: true,
+            autoActivate: false,
+            offsetSeconds: 0,
+            logMessage: 'Cascade armed recovery event',
+          },
+        ],
+        log: { message: 'Cascade applied', severity: 'warning' },
+        tags: [],
+        notes: null,
+        metadata: null,
+      }],
+    ]);
+
+    const events = [
+      {
+        id: 'FAIL_EVENT',
+        phase: 'Test',
+        getOpenSeconds: 0,
+        getCloseSeconds: 5,
+        prerequisites: [],
+        autopilotId: null,
+        checklistId: null,
+        padId: null,
+        successEffects: {},
+        failureEffects: { failure_id: 'FAIL_TEST' },
+      },
+      {
+        id: 'RECOVERY_EVENT',
+        phase: 'Test',
+        getOpenSeconds: 20,
+        getCloseSeconds: 30,
+        prerequisites: [],
+        autopilotId: null,
+        checklistId: null,
+        padId: null,
+        successEffects: {},
+        failureEffects: {},
+      },
+    ];
+
+    const scheduler = new EventScheduler(events, new Map(), resourceSystem, logger, {
+      failureCascades,
+    });
+
+    scheduler.update(0, 1);
+    scheduler.update(6, 1);
+
+    const failEvent = scheduler.getEventById('FAIL_EVENT');
+    assert.equal(failEvent.status, 'failed');
+    const recoveryEvent = scheduler.getEventById('RECOVERY_EVENT');
+    assert.ok(['armed', 'active'].includes(recoveryEvent.status));
+    assert.ok(Array.isArray(recoveryEvent.cascadeTriggers));
+    assert.equal(recoveryEvent.cascadeTriggers.length, 1);
+
+    const snapshot = resourceSystem.snapshot();
+    assert.equal(snapshot.power_margin_pct, 95);
+
+    assert.ok(
+      logger.entries.some((entry) => entry.message.includes('Cascade applied')),
+      'expected cascade log entry',
+    );
+  });
+
+  it('skips repeated application when cascade is not repeatable', () => {
+    const logger = createTestLogger();
+    const resourceSystem = new ResourceSystem(logger);
+    const failureCascades = new Map([
+      ['FAIL_REPEAT', {
+        id: 'FAIL_REPEAT',
+        resourceEffects: { power_margin_pct: -2 },
+        repeatable: false,
+        applyOnce: false,
+        armEvents: [],
+        log: null,
+        tags: [],
+        notes: null,
+        metadata: null,
+      }],
+    ]);
+
+    const events = [
+      {
+        id: 'EVENT_ONE',
+        phase: 'Test',
+        getOpenSeconds: 0,
+        getCloseSeconds: 5,
+        prerequisites: [],
+        successEffects: {},
+        failureEffects: { failure_id: 'FAIL_REPEAT' },
+      },
+      {
+        id: 'EVENT_TWO',
+        phase: 'Test',
+        getOpenSeconds: 10,
+        getCloseSeconds: 15,
+        prerequisites: [],
+        successEffects: {},
+        failureEffects: { failure_id: 'FAIL_REPEAT' },
+      },
+    ];
+
+    const scheduler = new EventScheduler(events, new Map(), resourceSystem, logger, {
+      failureCascades,
+    });
+
+    scheduler.update(0, 1);
+    scheduler.update(6, 1);
+    scheduler.update(16, 1);
+    scheduler.update(17, 1);
+
+    const snapshot = resourceSystem.snapshot();
+    assert.equal(snapshot.power_margin_pct, 98);
+  });
+
+  it('allows repeatable cascades to stack when enabled', () => {
+    const logger = createTestLogger();
+    const resourceSystem = new ResourceSystem(logger);
+    const failureCascades = new Map([
+      ['FAIL_REPEAT', {
+        id: 'FAIL_REPEAT',
+        resourceEffects: { power_margin_pct: -1 },
+        repeatable: true,
+        applyOnce: false,
+        armEvents: [],
+        log: null,
+        tags: [],
+        notes: null,
+        metadata: null,
+      }],
+    ]);
+
+    const events = [
+      {
+        id: 'EVENT_A',
+        phase: 'Test',
+        getOpenSeconds: 0,
+        getCloseSeconds: 5,
+        prerequisites: [],
+        successEffects: {},
+        failureEffects: { failure_id: 'FAIL_REPEAT' },
+      },
+      {
+        id: 'EVENT_B',
+        phase: 'Test',
+        getOpenSeconds: 10,
+        getCloseSeconds: 15,
+        prerequisites: [],
+        successEffects: {},
+        failureEffects: { failure_id: 'FAIL_REPEAT' },
+      },
+    ];
+
+    const scheduler = new EventScheduler(events, new Map(), resourceSystem, logger, {
+      failureCascades,
+    });
+
+    scheduler.update(0, 1);
+    scheduler.update(6, 1);
+    scheduler.update(16, 1);
+    scheduler.update(17, 1);
+
+    const snapshot = resourceSystem.snapshot();
+    assert.equal(snapshot.power_margin_pct, 98);
+  });
+});


### PR DESCRIPTION
## Summary
- add the failure_cascades.json dataset and expose it through the mission data loader
- expand the JS event scheduler to apply cascade resource effects, arm follow-up events, and log window overrides
- extend the resource system communications metrics and add coverage for cascade behaviour

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1919047a48323bdc93235c7b1862e