### PR TITLE
Add audio validation CLI and ledger analysis

### DIFF
--- a/docs/ui/audio_dispatcher_architecture.md
+++ b/docs/ui/audio_dispatcher_architecture.md
@@ -150,8 +150,10 @@ setting `event.audio_cue = 'MISSION_GO_TLI'` or by publishing an
    - Implement Web Audio mixer with bus graph, ducking matrix, and
      waveform preloading.
    - Integrate dispatcher into CLI HUD for headless testing (logs only).
-   - Build `npm run validate:audio` CLI to replay cue triggers and verify
-     cooldown/priority rules against catalog metadata.
+   - `npm run validate:audio` CLI in [`js/src/tools/validateAudio.js`](../../js/src/tools/validateAudio.js)
+     replays mission slices, inspects the dispatcher ledger for
+     concurrency, cooldown, and priority violations, and emits JSON
+     reports for regression tracking.【F:js/src/tools/validateAudio.js†L1-L220】【F:js/test/audioValidation.test.js†L1-L110】
 3. **Phase C – UI integration**
    - Hook Always-On HUD master alarm button to dispatcher mute/resume.
    - Surface captions in console dock, align highlight color with cue

--- a/js/README.md
+++ b/js/README.md
@@ -12,8 +12,10 @@ This workspace now includes a Node.js simulation harness that exercises the Apol
 - Streams mission log messages with GET stamps and can export them to JSON for regression playback (`src/logging/missionLogger.js`).
 - Replays autopilot JSON sequences through `AutopilotRunner` (`src/sim/autopilotRunner.js`), issuing ullage, attitude, and throttle commands while subtracting SPS/LM/RCS propellant usage from the shared resource model.
 - Captures auto-advanced checklist acknowledgements and exports them as deterministic manual action scripts when `--record-manual-script` is provided, enabling parity runs without relying on auto crew logic (`src/logging/manualActionRecorder.js`).
+- Manual action recorder exports now bundle workspace, panel, and audio ledgers so parity harnesses, HUD exports, and replay tooling can replay layout changes and the cue soundscape alongside checklist history (`src/logging/manualActionRecorder.js`).
 - Emits periodic text HUD snapshots (`src/hud/textHud.js`) summarizing event status, resource margins, propellant usage, checklist activity, and manual action queues so long running simulations remain legible from the CLI.
 - Exports deterministic `ui_frame` sequences for front-end prototyping through the new CLI in [`src/tools/exportUiFrames.js`](src/tools/exportUiFrames.js).
+- Audio validation CLI in [`src/tools/validateAudio.js`](src/tools/validateAudio.js) replays mission slices, inspects dispatcher-ledger stats for cooldown/priority/concurrency regressions, and emits optional JSON reports for regression tracking.
 - Carries the commander rating snapshot (`frame.score`) through both the CLI HUD and UI frame exporter so mission performance data is available to text output, saved frames, and future UI bindings.
 - Entry overlay config in [`docs/ui/entry_overlay.json`](../docs/ui/entry_overlay.json) now feeds `UiFrameBuilder`'s `frame.entry` payload with corridor, blackout, EMS, and recovery telemetry so downstream HUD experiments can render the TEI → splashdown finale without custom data stitching.
 

--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,8 @@
     "analyze:autopilots": "node ./src/tools/analyzeAutopilots.js",
     "export:ui-frames": "node ./src/tools/exportUiFrames.js",
     "export:workspace": "node ./src/tools/exportWorkspace.js",
-    "validate:data": "node ./src/tools/validateMissionData.js"
+    "validate:data": "node ./src/tools/validateMissionData.js",
+    "validate:audio": "node ./src/tools/validateAudio.js"
   },
   "engines": {
     "node": ">=18"

--- a/js/src/audio/audioDispatcher.js
+++ b/js/src/audio/audioDispatcher.js
@@ -112,6 +112,7 @@ export class AudioDispatcher {
     this.catalog = catalog && typeof catalog === 'object' ? catalog : { buses: [], categories: [], cues: [] };
     this.mixer = mixer ?? new NullAudioMixer({ logger: this.logger, logSource: this.logSource, logCategory: this.logCategory });
     this.binder = this.options.binder ?? null;
+    this.recorder = this.options.recorder ?? null;
 
     this.busMap = new Map();
     this.categoryMap = new Map();
@@ -427,6 +428,10 @@ export class AudioDispatcher {
     record.ledgerEntry = ledgerEntry;
     this.#appendLedgerEntry(ledgerEntry);
 
+    if (this.recorder?.recordAudioEvent) {
+      this.recorder.recordAudioEvent(clone(ledgerEntry));
+    }
+
     const state = this.#ensureBusState(busId);
     state.active.push(record);
 
@@ -494,6 +499,10 @@ export class AudioDispatcher {
         : reason === 'preempted'
           ? 'preempted'
           : 'stopped';
+
+      if (this.recorder?.recordAudioEvent) {
+        this.recorder.recordAudioEvent(clone(entry));
+      }
     }
   }
 

--- a/js/src/sim/simulationContext.js
+++ b/js/src/sim/simulationContext.js
@@ -67,6 +67,7 @@ export async function createSimulationContext({
   const audioDispatcher = new AudioDispatcher(missionData.audioCues, audioMixer, {
     logger,
     binder: audioBinder,
+    recorder: manualActionRecorder,
   });
 
   const checklistManager = new ChecklistManager(missionData.checklists, logger, {

--- a/js/src/tools/audioValidation.js
+++ b/js/src/tools/audioValidation.js
@@ -1,0 +1,422 @@
+import { formatGET } from '../utils/time.js';
+
+export const DEFAULT_SEVERITY_WEIGHTS = {
+  failure: 60,
+  warning: 30,
+  caution: 15,
+  notice: 5,
+  info: 0,
+};
+
+const DEFAULT_PRIORITY_TOLERANCE = 1e-3;
+const DEFAULT_COOLDOWN_TOLERANCE = 1e-3;
+
+function normalizeId(value) {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return String(value);
+}
+
+function coerceNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function toLowerCase(value, fallback = null) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed.toLowerCase();
+    }
+  }
+  return fallback;
+}
+
+function formatMaybeGET(seconds) {
+  return Number.isFinite(seconds) ? formatGET(seconds) : null;
+}
+
+function mapToArray(map, keyName) {
+  return Array.from(map.entries())
+    .map(([key, count]) => ({
+      [keyName]: key,
+      count,
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+      const aKey = a[keyName] ?? '';
+      const bKey = b[keyName] ?? '';
+      return aKey.localeCompare(bKey);
+    });
+}
+
+export function analyzeAudioLedger(ledger, catalog = null, options = {}) {
+  const severityWeights = {
+    ...DEFAULT_SEVERITY_WEIGHTS,
+    ...(options.severityWeights ?? {}),
+  };
+  const dispatcherStats = options.dispatcherStats ?? null;
+  const defaultBusConcurrency = Number.isFinite(options.defaultBusConcurrency)
+    && options.defaultBusConcurrency > 0
+    ? options.defaultBusConcurrency
+    : 1;
+  const priorityTolerance = Number.isFinite(options.priorityTolerance)
+    ? options.priorityTolerance
+    : DEFAULT_PRIORITY_TOLERANCE;
+  const cooldownTolerance = Number.isFinite(options.cooldownTolerance)
+    ? options.cooldownTolerance
+    : DEFAULT_COOLDOWN_TOLERANCE;
+
+  const busMap = new Map();
+  for (const bus of catalog?.buses ?? []) {
+    const id = normalizeId(bus?.id ?? bus?.busId);
+    if (!id) {
+      continue;
+    }
+    busMap.set(id, bus);
+  }
+
+  const categoryMap = new Map();
+  for (const category of catalog?.categories ?? []) {
+    const id = normalizeId(category?.id ?? category?.categoryId);
+    if (!id) {
+      continue;
+    }
+    categoryMap.set(id, category);
+  }
+
+  const cueMap = new Map();
+  for (const cue of catalog?.cues ?? []) {
+    const id = normalizeId(cue?.id ?? cue?.cueId);
+    if (!id) {
+      continue;
+    }
+    cueMap.set(id, cue);
+  }
+
+  const normalizedEntries = [];
+  const eventsByBus = new Map();
+  const entriesPerBus = new Map();
+  const counts = {
+    severity: new Map(),
+    status: new Map(),
+    bus: new Map(),
+    category: new Map(),
+  };
+
+  let earliestStartSeconds = null;
+  let latestEndSeconds = null;
+
+  const sourceEntries = Array.isArray(ledger) ? ledger : [];
+  for (const rawEntry of sourceEntries) {
+    if (!rawEntry || typeof rawEntry !== 'object') {
+      continue;
+    }
+
+    const playbackId = normalizeId(rawEntry.playbackId ?? rawEntry.id ?? rawEntry.playback_id);
+    const cueId = normalizeId(rawEntry.cueId ?? rawEntry.cue_id);
+    let categoryId = normalizeId(rawEntry.categoryId ?? rawEntry.category_id);
+    let busId = normalizeId(rawEntry.busId ?? rawEntry.bus_id);
+    const severity = toLowerCase(rawEntry.severity, 'info');
+    const status = toLowerCase(rawEntry.status, 'unknown');
+    const priority = coerceNumber(rawEntry.priority ?? rawEntry.priority_value);
+    const startedAtSeconds = coerceNumber(rawEntry.startedAtSeconds ?? rawEntry.started_at_seconds ?? rawEntry.started_at);
+    const endedAtSecondsRaw = coerceNumber(rawEntry.endedAtSeconds ?? rawEntry.ended_at_seconds ?? rawEntry.ended_at);
+    const durationSeconds = coerceNumber(rawEntry.durationSeconds ?? rawEntry.duration_seconds);
+
+    const cueMeta = cueId ? cueMap.get(cueId) ?? null : null;
+    if (!categoryId) {
+      categoryId = normalizeId(cueMeta?.category ?? cueMeta?.categoryId);
+    }
+    const categoryMeta = categoryId ? categoryMap.get(categoryId) ?? null : null;
+
+    if (!busId) {
+      busId = normalizeId(
+        cueMeta?.bus ?? cueMeta?.busId ?? cueMeta?.categoryBus ?? categoryMeta?.bus ?? categoryMeta?.busId,
+      );
+    }
+    if (!busId) {
+      busId = 'master';
+    }
+
+    const busMeta = busMap.get(busId) ?? null;
+    const busLimit = Number.isFinite(busMeta?.maxConcurrent)
+      ? Number(busMeta.maxConcurrent)
+      : defaultBusConcurrency;
+
+    const basePriorityRaw = coerceNumber(cueMeta?.priority ?? cueMeta?.priorityValue)
+      ?? coerceNumber(categoryMeta?.defaultPriority ?? categoryMeta?.priority);
+    const basePriority = Number.isFinite(basePriorityRaw) ? basePriorityRaw : 0;
+    const severityWeight = severityWeights[severity] ?? 0;
+    const expectedPriority = basePriority + severityWeight;
+
+    const endedAtSeconds = Number.isFinite(endedAtSecondsRaw)
+      ? endedAtSecondsRaw
+      : Number.isFinite(durationSeconds) && Number.isFinite(startedAtSeconds)
+        ? startedAtSeconds + durationSeconds
+        : null;
+
+    const normalized = {
+      playbackId,
+      cueId,
+      categoryId,
+      busId,
+      severity,
+      status,
+      priority,
+      expectedPriority,
+      basePriority,
+      severityWeight,
+      startedAtSeconds,
+      endedAtSeconds,
+      durationSeconds,
+      stopReason: rawEntry.stopReason ?? rawEntry.stop_reason ?? null,
+      cueCooldown: coerceNumber(cueMeta?.cooldownSeconds ?? cueMeta?.cooldown_seconds),
+      categoryCooldown: coerceNumber(categoryMeta?.cooldownSeconds ?? categoryMeta?.cooldown_seconds),
+      busLimit,
+    };
+
+    normalizedEntries.push(normalized);
+    entriesPerBus.set(busId, (entriesPerBus.get(busId) ?? 0) + 1);
+
+    counts.severity.set(severity, (counts.severity.get(severity) ?? 0) + 1);
+    counts.status.set(status, (counts.status.get(status) ?? 0) + 1);
+    counts.bus.set(busId, (counts.bus.get(busId) ?? 0) + 1);
+    if (categoryId) {
+      counts.category.set(categoryId, (counts.category.get(categoryId) ?? 0) + 1);
+    }
+
+    if (Number.isFinite(startedAtSeconds)) {
+      earliestStartSeconds = earliestStartSeconds == null
+        ? startedAtSeconds
+        : Math.min(earliestStartSeconds, startedAtSeconds);
+    }
+    const latestCandidate = Number.isFinite(endedAtSeconds)
+      ? endedAtSeconds
+      : Number.isFinite(startedAtSeconds)
+        ? startedAtSeconds
+        : null;
+    if (Number.isFinite(latestCandidate)) {
+      latestEndSeconds = latestEndSeconds == null
+        ? latestCandidate
+        : Math.max(latestEndSeconds, latestCandidate);
+    }
+
+    if (Number.isFinite(startedAtSeconds)) {
+      const events = eventsByBus.get(busId) ?? [];
+      events.push({
+        type: 'start',
+        time: startedAtSeconds,
+        playbackId,
+        entry: normalized,
+      });
+      if (Number.isFinite(endedAtSeconds)) {
+        events.push({
+          type: 'end',
+          time: Math.max(endedAtSeconds, startedAtSeconds),
+          playbackId,
+          entry: normalized,
+        });
+      }
+      eventsByBus.set(busId, events);
+    }
+  }
+
+  const concurrencySummaries = [];
+  const concurrencyViolations = [];
+  for (const [busId, events] of eventsByBus.entries()) {
+    const busMeta = busMap.get(busId) ?? null;
+    const limit = Number.isFinite(busMeta?.maxConcurrent)
+      ? Number(busMeta.maxConcurrent)
+      : defaultBusConcurrency;
+
+    if (!Array.isArray(events) || events.length === 0) {
+      concurrencySummaries.push({
+        busId,
+        limit,
+        maxObserved: 0,
+        entries: entriesPerBus.get(busId) ?? 0,
+      });
+      continue;
+    }
+
+    events.sort((a, b) => {
+      if (a.time !== b.time) {
+        return a.time - b.time;
+      }
+      if (a.type === b.type) {
+        return (a.playbackId ?? '').localeCompare(b.playbackId ?? '');
+      }
+      return a.type === 'end' ? -1 : 1;
+    });
+
+    const active = new Map();
+    let maxObserved = 0;
+    for (const event of events) {
+      if (event.type === 'end') {
+        active.delete(event.playbackId);
+        continue;
+      }
+      active.set(event.playbackId, event.entry);
+      const current = active.size;
+      if (current > maxObserved) {
+        maxObserved = current;
+      }
+      if (limit > 0 && current > limit) {
+        concurrencyViolations.push({
+          busId,
+          limit,
+          observed: current,
+          atSeconds: event.time,
+          at: formatMaybeGET(event.time),
+          activePlaybacks: Array.from(active.values()).map((entry) => ({
+            playbackId: entry.playbackId,
+            cueId: entry.cueId,
+            startedAtSeconds: entry.startedAtSeconds,
+            startedAt: formatMaybeGET(entry.startedAtSeconds),
+            priority: entry.priority,
+          })),
+        });
+      }
+    }
+
+    concurrencySummaries.push({
+      busId,
+      limit,
+      maxObserved,
+      entries: entriesPerBus.get(busId) ?? 0,
+    });
+  }
+
+  const cooldownViolations = [];
+  const cueLastStart = new Map();
+  const categoryLastStart = new Map();
+  const sortedByStart = normalizedEntries
+    .filter((entry) => Number.isFinite(entry.startedAtSeconds))
+    .sort((a, b) => {
+      if (a.startedAtSeconds !== b.startedAtSeconds) {
+        return a.startedAtSeconds - b.startedAtSeconds;
+      }
+      return (a.playbackId ?? '').localeCompare(b.playbackId ?? '');
+    });
+
+  for (const entry of sortedByStart) {
+    const { startedAtSeconds, cueCooldown, categoryCooldown } = entry;
+    if (!Number.isFinite(startedAtSeconds)) {
+      continue;
+    }
+
+    if (Number.isFinite(cueCooldown) && entry.cueId) {
+      const previous = cueLastStart.get(entry.cueId);
+      if (Number.isFinite(previous) && startedAtSeconds - previous < cueCooldown - cooldownTolerance) {
+        cooldownViolations.push({
+          type: 'cue',
+          cueId: entry.cueId,
+          requiredSeconds: cueCooldown,
+          observedGapSeconds: startedAtSeconds - previous,
+          previousStartSeconds: previous,
+          previousStart: formatMaybeGET(previous),
+          currentStartSeconds: startedAtSeconds,
+          currentStart: formatMaybeGET(startedAtSeconds),
+        });
+      }
+      cueLastStart.set(entry.cueId, startedAtSeconds);
+    }
+
+    if (Number.isFinite(categoryCooldown) && entry.categoryId) {
+      const previous = categoryLastStart.get(entry.categoryId);
+      if (Number.isFinite(previous) && startedAtSeconds - previous < categoryCooldown - cooldownTolerance) {
+        cooldownViolations.push({
+          type: 'category',
+          categoryId: entry.categoryId,
+          requiredSeconds: categoryCooldown,
+          observedGapSeconds: startedAtSeconds - previous,
+          previousStartSeconds: previous,
+          previousStart: formatMaybeGET(previous),
+          currentStartSeconds: startedAtSeconds,
+          currentStart: formatMaybeGET(startedAtSeconds),
+        });
+      }
+      categoryLastStart.set(entry.categoryId, startedAtSeconds);
+    }
+  }
+
+  const priorityMismatches = [];
+  for (const entry of normalizedEntries) {
+    if (!Number.isFinite(entry.expectedPriority)) {
+      continue;
+    }
+    if (!Number.isFinite(entry.priority)) {
+      priorityMismatches.push({
+        cueId: entry.cueId,
+        categoryId: entry.categoryId,
+        severity: entry.severity,
+        expectedPriority: entry.expectedPriority,
+        observedPriority: null,
+        delta: null,
+      });
+      continue;
+    }
+    const delta = entry.priority - entry.expectedPriority;
+    if (Math.abs(delta) > priorityTolerance) {
+      priorityMismatches.push({
+        cueId: entry.cueId,
+        categoryId: entry.categoryId,
+        severity: entry.severity,
+        expectedPriority: entry.expectedPriority,
+        observedPriority: entry.priority,
+        delta,
+      });
+    }
+  }
+
+  const suppressedTriggers = dispatcherStats?.suppressed ?? 0;
+  const droppedTriggers = dispatcherStats?.dropped ?? 0;
+
+  const analysis = {
+    totals: {
+      ledgerEntries: normalizedEntries.length,
+      buses: busMap.size,
+      categories: categoryMap.size,
+      cues: cueMap.size,
+    },
+    counts: {
+      bySeverity: mapToArray(counts.severity, 'severity'),
+      byStatus: mapToArray(counts.status, 'status'),
+      byBus: mapToArray(counts.bus, 'busId'),
+      byCategory: mapToArray(counts.category, 'categoryId'),
+    },
+    concurrency: {
+      byBus: concurrencySummaries.sort((a, b) => a.busId.localeCompare(b.busId)),
+      violations: concurrencyViolations,
+    },
+    cooldownViolations,
+    priorityMismatches,
+    suppressedTriggers,
+    droppedTriggers,
+    severityWeights,
+    dispatcherStats,
+    timeline: {
+      earliestStartSeconds,
+      earliestStart: formatMaybeGET(earliestStartSeconds),
+      latestEndSeconds,
+      latestEnd: formatMaybeGET(latestEndSeconds),
+    },
+  };
+
+  analysis.isHealthy =
+    concurrencyViolations.length === 0
+    && cooldownViolations.length === 0
+    && priorityMismatches.length === 0
+    && droppedTriggers === 0;
+
+  return analysis;
+}
+

--- a/js/src/tools/validateAudio.js
+++ b/js/src/tools/validateAudio.js
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import process from 'process';
+
+import { DATA_DIR } from '../config/paths.js';
+import { MissionLogger } from '../logging/missionLogger.js';
+import { createSimulationContext } from '../sim/simulationContext.js';
+import { formatGET, parseGET } from '../utils/time.js';
+import { analyzeAudioLedger } from './audioValidation.js';
+
+const DEFAULTS = {
+  untilSeconds: parseGET('015:00:00'),
+  tickRate: 20,
+  logIntervalSeconds: 3600,
+  checklistStepSeconds: 15,
+  autoChecklists: true,
+  includeLedger: false,
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!Number.isFinite(args.untilSeconds) || args.untilSeconds <= 0) {
+    throw new Error('--until requires a positive GET value (e.g., 015:00:00).');
+  }
+
+  const logger = new MissionLogger({ silent: !args.verbose });
+
+  const context = await createSimulationContext({
+    dataDir: args.dataDir,
+    logger,
+    tickRate: args.tickRate,
+    logIntervalSeconds: args.logIntervalSeconds,
+    autoAdvanceChecklists: args.autoChecklists,
+    checklistStepSeconds: args.checklistStepSeconds,
+    manualActionScriptPath: args.manualScriptPath,
+    hudOptions: { enabled: false },
+  });
+
+  const summary = context.simulation.run({ untilGetSeconds: args.untilSeconds });
+  const finalGetSeconds = summary.finalGetSeconds
+    ?? context.simulation?.clock?.getCurrent?.()
+    ?? args.untilSeconds;
+
+  if (context.audioDispatcher?.stopAll) {
+    context.audioDispatcher.stopAll('validation_complete', finalGetSeconds);
+  }
+
+  const ledger = context.audioDispatcher?.ledgerSnapshot?.() ?? [];
+  const dispatcherStats = context.audioDispatcher?.statsSnapshot?.() ?? null;
+  const severityWeights = context.audioDispatcher?.options?.severityWeights ?? null;
+  const defaultBusConcurrency = context.audioDispatcher?.options?.defaultMaxConcurrent ?? 1;
+
+  const analysis = analyzeAudioLedger(ledger, context.audioCues ?? null, {
+    dispatcherStats,
+    severityWeights,
+    defaultBusConcurrency,
+  });
+
+  const metadata = {
+    generatedAt: new Date().toISOString(),
+    dataDir: context.options?.dataDir ?? args.dataDir,
+    untilGet: formatGET(args.untilSeconds),
+    finalGet: formatGET(finalGetSeconds),
+    tickRate: args.tickRate,
+    logIntervalSeconds: args.logIntervalSeconds,
+    checklistStepSeconds: args.checklistStepSeconds,
+    autoChecklists: args.autoChecklists,
+    manualScript: args.manualScriptPath ? path.resolve(args.manualScriptPath) : null,
+  };
+
+  const report = {
+    metadata,
+    summary: {
+      simulation: {
+        ticks: summary.ticks,
+        finalGetSeconds: summary.finalGetSeconds,
+        events: summary.events,
+        score: summary.score,
+      },
+      audio: {
+        analysis,
+        dispatcherStats,
+        ledger: args.includeLedger ? ledger : undefined,
+      },
+    },
+  };
+
+  if (!args.quiet) {
+    printSummary(analysis, {
+      untilSeconds: args.untilSeconds,
+      finalGetSeconds,
+    });
+  }
+
+  if (args.reportPath) {
+    const outputPath = path.resolve(args.reportPath);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, JSON.stringify(report, null, args.pretty ? 2 : 0), 'utf8');
+    if (!args.quiet) {
+      console.log(`Wrote audio validation report to ${outputPath}`);
+    }
+  }
+
+  if (!analysis.isHealthy) {
+    process.exitCode = 1;
+    if (!args.quiet) {
+      console.error('Audio validation detected issues. See report for details.');
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    dataDir: DATA_DIR,
+    untilSeconds: DEFAULTS.untilSeconds,
+    tickRate: DEFAULTS.tickRate,
+    logIntervalSeconds: DEFAULTS.logIntervalSeconds,
+    checklistStepSeconds: DEFAULTS.checklistStepSeconds,
+    autoChecklists: DEFAULTS.autoChecklists,
+    manualScriptPath: null,
+    reportPath: null,
+    includeLedger: DEFAULTS.includeLedger,
+    pretty: false,
+    quiet: false,
+    verbose: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      case '--data-dir': {
+        const next = argv[i + 1];
+        if (!next) {
+          throw new Error('--data-dir requires a path.');
+        }
+        args.dataDir = path.resolve(next);
+        i += 1;
+        break;
+      }
+      case '--until': {
+        const next = argv[i + 1];
+        if (!next) {
+          throw new Error('--until requires a GET value (e.g., 015:00:00).');
+        }
+        const parsed = parseGET(next);
+        if (!Number.isFinite(parsed)) {
+          throw new Error(`Invalid GET for --until: ${next}`);
+        }
+        args.untilSeconds = parsed;
+        i += 1;
+        break;
+      }
+      case '--tick-rate': {
+        const next = Number(argv[i + 1]);
+        if (!Number.isFinite(next) || next <= 0) {
+          throw new Error('--tick-rate requires a positive number.');
+        }
+        args.tickRate = next;
+        i += 1;
+        break;
+      }
+      case '--log-interval': {
+        const next = Number(argv[i + 1]);
+        if (!Number.isFinite(next) || next <= 0) {
+          throw new Error('--log-interval requires a positive number of seconds.');
+        }
+        args.logIntervalSeconds = next;
+        i += 1;
+        break;
+      }
+      case '--checklist-step-seconds': {
+        const next = Number(argv[i + 1]);
+        if (!Number.isFinite(next) || next <= 0) {
+          throw new Error('--checklist-step-seconds requires a positive number.');
+        }
+        args.checklistStepSeconds = next;
+        i += 1;
+        break;
+      }
+      case '--manual-checklists':
+        args.autoChecklists = false;
+        break;
+      case '--auto-checklists':
+        args.autoChecklists = true;
+        break;
+      case '--manual-script': {
+        const next = argv[i + 1];
+        if (!next) {
+          throw new Error('--manual-script requires a file path.');
+        }
+        args.manualScriptPath = next;
+        i += 1;
+        break;
+      }
+      case '--report':
+      case '--output':
+      case '-o': {
+        const next = argv[i + 1];
+        if (!next) {
+          throw new Error('--report requires a file path.');
+        }
+        args.reportPath = next;
+        i += 1;
+        break;
+      }
+      case '--include-ledger':
+        args.includeLedger = true;
+        break;
+      case '--pretty':
+        args.pretty = true;
+        break;
+      case '--quiet':
+        args.quiet = true;
+        break;
+      case '--verbose':
+        args.verbose = true;
+        args.quiet = false;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function printSummary(analysis, { untilSeconds, finalGetSeconds }) {
+  const timelineStart = analysis.timeline?.earliestStart ?? '000:00:00';
+  const timelineEnd = analysis.timeline?.latestEnd ?? formatGET(finalGetSeconds);
+  const ledgerCount = analysis.totals?.ledgerEntries ?? 0;
+  console.log(
+    `Audio validation processed ${ledgerCount} ledger entr${ledgerCount === 1 ? 'y' : 'ies'} `
+      + `from GET ${timelineStart} to ${timelineEnd} (target ${formatGET(untilSeconds)}).`,
+  );
+
+  if (analysis.concurrency?.byBus?.length > 0) {
+    console.log('Max concurrent playback per bus:');
+    for (const bus of analysis.concurrency.byBus) {
+      console.log(
+        `  ${bus.busId}: observed ${bus.maxObserved} / limit ${bus.limit} `
+          + `(entries ${bus.entries})`,
+      );
+    }
+  }
+
+  if (analysis.suppressedTriggers > 0) {
+    console.warn(`Suppressed triggers: ${analysis.suppressedTriggers}`);
+  }
+  if (analysis.droppedTriggers > 0) {
+    console.warn(`Dropped triggers: ${analysis.droppedTriggers}`);
+  }
+
+  if (analysis.concurrency?.violations?.length > 0) {
+    console.warn(`Concurrency violations: ${analysis.concurrency.violations.length}`);
+  }
+  if (analysis.cooldownViolations?.length > 0) {
+    console.warn(`Cooldown violations: ${analysis.cooldownViolations.length}`);
+  }
+  if (analysis.priorityMismatches?.length > 0) {
+    console.warn(`Priority mismatches: ${analysis.priorityMismatches.length}`);
+  }
+
+  if (analysis.isHealthy) {
+    console.log('Audio validation completed without critical issues.');
+  }
+}
+
+function printHelp() {
+  const lines = [
+    'Usage: node ./src/tools/validateAudio.js [options]',
+    '',
+    'Options:',
+    '  --until <GET>                Mission GET to stop the simulation (default 015:00:00)',
+    '  --tick-rate <hz>             Simulation tick rate (default 20)',
+    '  --log-interval <seconds>     Resource logging cadence (default 3600)',
+    '  --checklist-step-seconds <s> Auto checklist step duration (default 15)',
+    '  --manual-checklists          Disable auto checklist advancement during validation',
+    '  --auto-checklists            Enable auto checklist advancement (default)',
+    '  --manual-script <path>       Replay a manual action script while validating',
+    '  --data-dir <path>            Override mission dataset directory',
+    '  --report <path>              Write JSON report to the specified path',
+    '  --include-ledger             Include the full audio ledger in the JSON report',
+    '  --pretty                     Pretty-print JSON output',
+    '  --quiet                      Suppress console output',
+    '  --verbose                    Print simulation logs and summary output',
+    '  --help                       Show this message',
+  ];
+  console.log(lines.join('\n'));
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});
+

--- a/js/test/audioValidation.test.js
+++ b/js/test/audioValidation.test.js
@@ -1,0 +1,133 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { analyzeAudioLedger, DEFAULT_SEVERITY_WEIGHTS } from '../src/tools/audioValidation.js';
+
+const TEST_CATALOG = {
+  buses: [
+    { id: 'alerts', maxConcurrent: 1 },
+    { id: 'dialogue', maxConcurrent: 1 },
+    { id: 'ambience', maxConcurrent: 2 },
+  ],
+  categories: [
+    { id: 'alert', bus: 'alerts', cooldownSeconds: 2 },
+    { id: 'callout', bus: 'dialogue', defaultPriority: 70 },
+    { id: 'ambient', bus: 'ambience', defaultPriority: 10 },
+  ],
+  cues: [
+    { id: 'alerts.master_alarm', category: 'alert', priority: 0, cooldownSeconds: 2 },
+    { id: 'callouts.go', category: 'callout', priority: 70 },
+    { id: 'ambient.cabin', category: 'ambient', priority: 10 },
+  ],
+};
+
+describe('analyzeAudioLedger', () => {
+  test('detects bus concurrency and cooldown violations', () => {
+    const ledger = [
+      {
+        id: 1,
+        cueId: 'alerts.master_alarm',
+        categoryId: 'alert',
+        busId: 'alerts',
+        severity: 'failure',
+        priority: DEFAULT_SEVERITY_WEIGHTS.failure,
+        startedAtSeconds: 10,
+        endedAtSeconds: 15,
+        status: 'completed',
+      },
+      {
+        id: 2,
+        cueId: 'alerts.master_alarm',
+        categoryId: 'alert',
+        busId: 'alerts',
+        severity: 'failure',
+        priority: DEFAULT_SEVERITY_WEIGHTS.failure,
+        startedAtSeconds: 11,
+        endedAtSeconds: 12,
+        status: 'completed',
+      },
+    ];
+
+    const analysis = analyzeAudioLedger(ledger, TEST_CATALOG);
+
+    assert.equal(analysis.concurrency.violations.length, 1);
+    assert.equal(analysis.concurrency.violations[0].busId, 'alerts');
+    assert.equal(analysis.concurrency.violations[0].observed > 1, true);
+    assert.equal(analysis.cooldownViolations.length, 2);
+    assert.deepEqual(
+      analysis.cooldownViolations.map((violation) => violation.type),
+      ['cue', 'category'],
+    );
+    assert.equal(analysis.isHealthy, false);
+  });
+
+  test('flags priority mismatches when playback priority deviates from catalog expectations', () => {
+    const ledger = [
+      {
+        id: 3,
+        cueId: 'callouts.go',
+        categoryId: 'callout',
+        busId: 'dialogue',
+        severity: 'notice',
+        priority: 20,
+        startedAtSeconds: 30,
+        endedAtSeconds: 33,
+        status: 'completed',
+      },
+    ];
+
+    const analysis = analyzeAudioLedger(ledger, TEST_CATALOG);
+
+    assert.equal(analysis.priorityMismatches.length, 1);
+    assert.equal(analysis.priorityMismatches[0].cueId, 'callouts.go');
+    assert.notEqual(Math.abs(analysis.priorityMismatches[0].delta) <= 1e-3, true);
+    assert.equal(analysis.isHealthy, false);
+  });
+
+  test('summarizes ledger stats when entries satisfy catalog rules', () => {
+    const ledger = [
+      {
+        id: 'ambient-1',
+        cueId: 'ambient.cabin',
+        categoryId: 'ambient',
+        busId: 'ambience',
+        severity: 'info',
+        priority: 10,
+        startedAtSeconds: 0,
+        endedAtSeconds: 60,
+        status: 'completed',
+      },
+      {
+        id: 'callout-1',
+        cueId: 'callouts.go',
+        categoryId: 'callout',
+        busId: 'dialogue',
+        severity: 'notice',
+        priority: 75,
+        startedAtSeconds: 90,
+        endedAtSeconds: 93,
+        status: 'completed',
+      },
+    ];
+
+    const analysis = analyzeAudioLedger(ledger, TEST_CATALOG);
+
+    assert.equal(analysis.isHealthy, true);
+    assert.equal(analysis.concurrency.violations.length, 0);
+    assert.equal(analysis.cooldownViolations.length, 0);
+    assert.equal(analysis.priorityMismatches.length, 0);
+
+    const dialogueSummary = analysis.concurrency.byBus.find((entry) => entry.busId === 'dialogue');
+    assert.ok(dialogueSummary);
+    assert.equal(dialogueSummary.maxObserved, 1);
+
+    const severityCounts = analysis.counts.bySeverity.reduce((map, entry) => ({
+      ...map,
+      [entry.severity]: entry.count,
+    }), {});
+    assert.equal(severityCounts.info, 1);
+    assert.equal(severityCounts.notice, 1);
+    assert.equal(analysis.timeline.earliestStart, '000:00:00');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add an audio ledger analysis helper used to examine concurrency, cooldown, and priority issues and cover it with targeted unit tests
- introduce a `validate:audio` CLI that replays a mission slice, summarizes dispatcher health, and optionally emits JSON reports
- document the recorder’s new audio stream alongside README and dispatcher roadmap updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f91848048323ad40a881239cf177