### PR TITLE
Add browser mission HUD MVP for JS prototype

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -73,6 +73,22 @@ Key options:
 
 The exporter writes a JSON payload containing metadata, the simulation summary, and an ordered array of `ui_frame` objects that follow the schema documented in [`docs/ui/ui_frame_reference.md`](../docs/ui/ui_frame_reference.md).
 
+## Mission HUD Web Demo
+
+Launch the browser-based mission HUD with:
+
+```
+npm run dev
+```
+
+The server streams simulation frames to the UI via Server-Sent Events. Visit [`http://localhost:3000`](http://localhost:3000) to watch the mission progress in real time. The visual MVP includes:
+
+- A persistent HUD with GET/MET, next event countdown, resource bars, comms status, and live commander score.
+- Three views—Navigation, Controls, and Systems—mirroring the project plan's layout. Tabs toggle between trajectory/timeline context, checklist & AGC details, and resource/performance telemetry.
+- Mission log feed and alert banner reacting to warnings, cautions, and failures surfaced by the simulator.
+
+Use the “Restart Simulation” button to trigger a fresh full-mission run without reloading the page. The CLI simulator remains available through `npm start` for text HUD and data exports.
+
 ## Autopilot Burn Analyzer
 
 Inspect autopilot execution metrics against historical PADs and tolerance envelopes with:

--- a/js/package.json
+++ b/js/package.json
@@ -13,7 +13,9 @@
     "export:ui-frames": "node ./src/tools/exportUiFrames.js",
     "export:workspace": "node ./src/tools/exportWorkspace.js",
     "validate:data": "node ./src/tools/validateMissionData.js",
-    "validate:audio": "node ./src/tools/validateAudio.js"
+    "validate:audio": "node ./src/tools/validateAudio.js",
+    "dev": "node ./src/server/index.js",
+    "start:ui": "node ./src/server/index.js"
   },
   "engines": {
     "node": ">=18"

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1,0 +1,742 @@
+const state = {
+  status: 'idle',
+  targetSeconds: null,
+  sampleSeconds: 60,
+  frames: [],
+  currentFrame: null,
+  summary: null,
+  activeView: 'navigation',
+};
+
+let eventSource = null;
+
+const dom = {
+  hud: {
+    get: document.getElementById('hud-get'),
+    met: document.getElementById('hud-met'),
+    next: document.getElementById('hud-next'),
+    nextPad: document.getElementById('hud-next-pad'),
+    power: document.getElementById('hud-power'),
+    deltaV: document.getElementById('hud-delta-v'),
+    comms: document.getElementById('hud-comms'),
+    score: document.getElementById('hud-score'),
+    scoreDetail: document.getElementById('hud-score-detail'),
+    status: document.getElementById('hud-status'),
+    progress: document.getElementById('hud-progress'),
+    progressBar: document.querySelector('.progress-bar'),
+  },
+  alertBanner: document.getElementById('alert-banner'),
+  navigation: {
+    trajectory: document.getElementById('nav-trajectory'),
+    upcoming: document.getElementById('nav-upcoming'),
+    autopilot: document.getElementById('nav-autopilot'),
+  },
+  controls: {
+    checklists: document.getElementById('controls-checklists'),
+    agc: document.getElementById('controls-agc'),
+    manual: document.getElementById('controls-manual'),
+  },
+  systems: {
+    resources: document.getElementById('systems-resources'),
+    thermal: document.getElementById('systems-thermal'),
+    performance: document.getElementById('systems-performance'),
+  },
+  missionLog: document.getElementById('mission-log'),
+  summary: document.getElementById('summary-panel'),
+  restartButton: document.getElementById('restart-button'),
+  viewTabs: document.querySelectorAll('.tab-button'),
+  views: document.querySelectorAll('.view'),
+};
+
+function init() {
+  setupViewTabs();
+  dom.restartButton?.addEventListener('click', () => {
+    connectStream();
+  });
+
+  if (!('EventSource' in window)) {
+    state.status = 'unsupported';
+    render();
+    dom.summary.textContent = 'Your browser does not support live mission streaming.';
+    return;
+  }
+
+  connectStream();
+}
+
+function setupViewTabs() {
+  dom.viewTabs.forEach((button) => {
+    const view = button.dataset.view;
+    if (!view) {
+      return;
+    }
+    button.id = `tab-${view}`;
+    button.setAttribute('aria-controls', `view-${view}`);
+    button.addEventListener('click', () => switchView(view));
+  });
+  updateViewVisibility();
+}
+
+function switchView(view) {
+  if (!view || state.activeView === view) {
+    return;
+  }
+  state.activeView = view;
+  updateViewVisibility();
+}
+
+function updateViewVisibility() {
+  dom.viewTabs.forEach((button) => {
+    const view = button.dataset.view;
+    button.classList.toggle('active', view === state.activeView);
+  });
+  dom.views.forEach((section) => {
+    section.classList.toggle('active', section.id === `view-${state.activeView}`);
+  });
+}
+
+function connectStream() {
+  cleanupStream();
+  state.status = 'connecting';
+  state.frames = [];
+  state.currentFrame = null;
+  state.summary = null;
+  state.targetSeconds = null;
+  render();
+
+  eventSource = new EventSource('/api/stream');
+  eventSource.addEventListener('status', (event) => {
+    const payload = safeParse(event.data);
+    if (!payload) {
+      return;
+    }
+    state.status = payload.state ?? state.status;
+    state.sampleSeconds = Number.isFinite(payload.sampleSeconds) ? payload.sampleSeconds : state.sampleSeconds;
+    if (Number.isFinite(payload.untilGetSeconds)) {
+      state.targetSeconds = payload.untilGetSeconds;
+    }
+    render();
+  });
+
+  const frameHandler = (event) => {
+    const payload = safeParse(event.data);
+    if (!payload) {
+      return;
+    }
+    state.status = 'running';
+    appendFrame(payload);
+    render();
+  };
+
+  eventSource.addEventListener('frame', frameHandler);
+  eventSource.addEventListener('final-frame', frameHandler);
+  eventSource.addEventListener('summary', (event) => {
+    const payload = safeParse(event.data);
+    if (!payload) {
+      return;
+    }
+    state.summary = payload;
+    render();
+  });
+  eventSource.addEventListener('complete', () => {
+    state.status = 'complete';
+    render();
+    cleanupStream();
+  });
+  eventSource.addEventListener('error', () => {
+    if (state.status !== 'complete') {
+      state.status = 'error';
+      render();
+    }
+    cleanupStream();
+  });
+}
+
+function cleanupStream() {
+  if (eventSource) {
+    eventSource.close();
+    eventSource = null;
+  }
+}
+
+function appendFrame(frame) {
+  if (!frame || typeof frame !== 'object') {
+    return;
+  }
+  const last = state.frames[state.frames.length - 1];
+  if (last && last.time?.getSeconds === frame.time?.getSeconds) {
+    state.frames[state.frames.length - 1] = frame;
+  } else {
+    state.frames.push(frame);
+  }
+  state.currentFrame = frame;
+}
+
+function safeParse(data) {
+  try {
+    return JSON.parse(data);
+  } catch (error) {
+    console.warn('Failed to parse event payload', error);
+    return null;
+  }
+}
+
+function render() {
+  renderHud();
+  renderAlertBanner();
+  renderNavigationView();
+  renderControlsView();
+  renderSystemsView();
+  renderMissionLog();
+  renderSummary();
+}
+
+function renderHud() {
+  const frame = state.currentFrame;
+  setText(dom.hud.get, frame?.time?.get ?? '--:--:--');
+  setText(dom.hud.met, frame?.time?.met ? `MET ${frame.time.met}` : 'MET --:--:--');
+
+  const next = frame?.events?.next;
+  if (next) {
+    const phase = next.phase ? ` (${next.phase})` : '';
+    const status = next.status ? ` – ${next.status}` : '';
+    const tMinus = next.tMinusLabel ?? 'TBD';
+    dom.hud.next.textContent = `${next.id ?? 'Event'}${phase}${status}`;
+    dom.hud.nextPad.textContent = tMinus;
+  } else if (dom.hud.next) {
+    dom.hud.next.textContent = 'No upcoming events';
+    dom.hud.nextPad.textContent = '';
+  }
+
+  const powerMargin = frame?.resources?.power?.marginPct;
+  dom.hud.power.textContent = powerMargin != null ? `${formatNumber(powerMargin, { digits: 1 })}%` : '--%';
+
+  const deltaV = frame?.resources?.deltaV?.totalMps;
+  dom.hud.deltaV.textContent = deltaV != null ? `${formatNumber(deltaV, { digits: 0 })} m/s` : '-- m/s';
+
+  const comms = frame?.resources?.communications;
+  if (comms?.current?.station) {
+    const parts = [comms.current.station];
+    if (comms.current.timeRemainingLabel) {
+      parts.push(comms.current.timeRemainingLabel);
+    }
+    if (comms.current.signalStrengthDb != null) {
+      parts.push(`${formatNumber(comms.current.signalStrengthDb, { digits: 1 })} dB`);
+    }
+    dom.hud.comms.textContent = parts.join(' · ');
+  } else if (comms?.nextWindowOpenGet) {
+    const label = comms.timeUntilNextWindowLabel ?? comms.nextWindowOpenGet;
+    dom.hud.comms.textContent = `Next pass ${label}`;
+  } else {
+    dom.hud.comms.textContent = 'Idle';
+  }
+
+  const score = frame?.score?.rating;
+  if (score) {
+    const grade = score.grade ?? '—';
+    const commanderScore = score.commanderScore != null
+      ? `${formatNumber(score.commanderScore, { digits: 1 })}`
+      : '—';
+    dom.hud.score.textContent = `Grade ${grade}`;
+    dom.hud.scoreDetail.textContent = `Commander ${commanderScore}`;
+  } else {
+    dom.hud.score.textContent = '--';
+    dom.hud.scoreDetail.textContent = 'Commander score';
+  }
+
+  const statusLabel = mapStatus(state.status);
+  dom.hud.status.textContent = statusLabel;
+
+  const progress = computeProgress(frame?.time?.getSeconds, state.targetSeconds);
+  if (progress != null) {
+    dom.hud.progress.style.width = `${progress}%`;
+    if (dom.hud.progressBar) {
+      dom.hud.progressBar.setAttribute('aria-valuenow', String(progress));
+    }
+  } else {
+    dom.hud.progress.style.width = '0%';
+    if (dom.hud.progressBar) {
+      dom.hud.progressBar.setAttribute('aria-valuenow', '0');
+    }
+  }
+}
+
+function renderAlertBanner() {
+  const banner = dom.alertBanner;
+  if (!banner) {
+    return;
+  }
+  const alerts = state.currentFrame?.alerts;
+  const failures = alerts?.failures ?? [];
+  const warnings = alerts?.warnings ?? [];
+  const cautions = alerts?.cautions ?? [];
+
+  banner.className = 'alert-banner';
+  banner.textContent = '';
+
+  if (failures.length > 0) {
+    banner.classList.add('active', 'failure');
+    banner.textContent = formatAlertList('Critical', failures);
+  } else if (warnings.length > 0) {
+    banner.classList.add('active', 'warning');
+    banner.textContent = formatAlertList('Warning', warnings);
+  } else if (cautions.length > 0) {
+    banner.classList.add('active');
+    banner.textContent = formatAlertList('Caution', cautions);
+  }
+}
+
+function formatAlertList(prefix, list) {
+  const labels = list
+    .map((item) => item.label ?? item.id ?? item.message)
+    .filter(Boolean)
+    .slice(0, 3);
+  return labels.length > 0 ? `${prefix}: ${labels.join(', ')}` : `${prefix} alert`; 
+}
+
+function renderNavigationView() {
+  const frame = state.currentFrame;
+  renderTrajectory(frame?.trajectory);
+  renderUpcoming(frame?.events?.upcoming);
+  renderAutopilot(frame?.autopilot);
+}
+
+function renderTrajectory(trajectory) {
+  const container = dom.navigation.trajectory;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!trajectory) {
+    container.textContent = 'No trajectory data yet.';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+
+  const body = trajectory.body?.name ?? trajectory.body?.id ?? 'Unknown body';
+  fragment.appendChild(createParagraph(`${body} frame`));
+
+  const stats = document.createElement('div');
+  stats.className = 'progress-grid';
+  stats.appendChild(createTile('Altitude', trajectory.altitudeKm != null ? `${formatNumber(trajectory.altitudeKm, { digits: 0 })} km` : '—'));
+  stats.appendChild(createTile('Speed', trajectory.speedKmPerSec != null ? `${formatNumber(trajectory.speedKmPerSec, { digits: 3 })} km/s` : '—'));
+  if (trajectory.elements) {
+    stats.appendChild(createTile('Apoapsis', trajectory.elements.apoapsisKm != null ? `${formatNumber(trajectory.elements.apoapsisKm, { digits: 0 })} km` : '—'));
+    stats.appendChild(createTile('Periapsis', trajectory.elements.periapsisKm != null ? `${formatNumber(trajectory.elements.periapsisKm, { digits: 0 })} km` : '—'));
+    stats.appendChild(createTile('Eccentricity', trajectory.elements.eccentricity != null ? formatNumber(trajectory.elements.eccentricity, { digits: 4 }) : '—'));
+  }
+  fragment.appendChild(stats);
+
+  container.appendChild(fragment);
+}
+
+function renderUpcoming(upcoming) {
+  const list = dom.navigation.upcoming;
+  if (!list) {
+    return;
+  }
+  list.textContent = '';
+  if (!Array.isArray(upcoming) || upcoming.length === 0) {
+    list.appendChild(createListItem('No upcoming events scheduled.'));
+    return;
+  }
+  upcoming.forEach((event) => {
+    const item = document.createElement('li');
+    item.className = 'list-item';
+
+    const title = document.createElement('strong');
+    const phase = event.phase ? ` (${event.phase})` : '';
+    title.textContent = `${event.id ?? 'Event'}${phase}`;
+    item.appendChild(title);
+
+    const tMinus = document.createElement('span');
+    tMinus.textContent = `T${event.tMinusLabel ?? '—'}`;
+    tMinus.className = 'badge';
+    item.appendChild(tMinus);
+
+    if (event.pad?.tig) {
+      const pad = document.createElement('span');
+      pad.textContent = `TIG ${event.pad.tig}`;
+      pad.className = 'hud-subvalue';
+      item.appendChild(pad);
+    }
+
+    list.appendChild(item);
+  });
+}
+
+function renderAutopilot(autopilot) {
+  const container = dom.navigation.autopilot;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!autopilot) {
+    container.textContent = 'Autopilot idle.';
+    return;
+  }
+  const parts = [];
+  if (autopilot.primary) {
+    const primary = autopilot.primary;
+    const progressLabel = primary.progress != null ? `${formatNumber(primary.progress * 100, { digits: 0 })}%` : '—';
+    parts.push(`Primary ${primary.id ?? 'PGM'} (${progressLabel})`);
+    if (primary.pad?.tig) {
+      parts.push(`TIG ${primary.pad.tig}`);
+    }
+  }
+  parts.push(`Active ${autopilot.counts?.active ?? 0}`);
+  parts.push(`Completed ${autopilot.counts?.completed ?? 0}`);
+  container.appendChild(createParagraph(parts.join(' · ')));
+
+  if (Array.isArray(autopilot.active) && autopilot.active.length > 0) {
+    const list = document.createElement('ul');
+    list.className = 'list';
+    autopilot.active.forEach((entry) => {
+      const li = document.createElement('li');
+      li.className = 'list-item';
+      const title = document.createElement('strong');
+      title.textContent = entry.id ?? entry.label ?? 'Autopilot';
+      li.appendChild(title);
+      if (entry.pad?.tig) {
+        li.appendChild(createParagraph(`TIG ${entry.pad.tig}`));
+      }
+      list.appendChild(li);
+    });
+    container.appendChild(list);
+  }
+}
+
+function renderControlsView() {
+  const frame = state.currentFrame;
+  renderChecklists(frame?.checklists);
+  renderAgc(frame?.agc);
+  renderManualQueue(frame?.manualQueue);
+}
+
+function renderChecklists(checklists) {
+  const container = dom.controls.checklists;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!checklists || !Array.isArray(checklists.active) || checklists.active.length === 0) {
+    container.textContent = 'No active checklists.';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  checklists.active.forEach((entry) => {
+    const card = document.createElement('div');
+    card.className = 'checklist-card';
+
+    const title = document.createElement('strong');
+    title.textContent = entry.title ?? entry.checklistId ?? 'Checklist';
+    card.appendChild(title);
+
+    const steps = document.createElement('div');
+    const completed = entry.completedSteps ?? 0;
+    const total = entry.totalSteps ?? '—';
+    steps.className = 'checklist-steps';
+    steps.textContent = `Step ${entry.nextStepNumber ?? completed + 1} • ${completed}/${total}`;
+    card.appendChild(steps);
+
+    if (entry.nextStepAction) {
+      card.appendChild(createParagraph(entry.nextStepAction));
+    }
+    if (entry.pad?.tig) {
+      card.appendChild(createParagraph(`TIG ${entry.pad.tig}`));
+    }
+    fragment.appendChild(card);
+  });
+  container.appendChild(fragment);
+}
+
+function renderAgc(agc) {
+  const container = dom.controls.agc;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!agc) {
+    container.textContent = 'Awaiting AGC state…';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  const program = agc.program ?? {};
+  fragment.appendChild(createParagraph(`Program ${program.current ?? '---'} • Verb ${program.verbLabel ?? '--'} · Noun ${program.nounLabel ?? '--'}`));
+  if (agc.pendingAck) {
+    fragment.appendChild(createParagraph(`Pending ACK ${agc.pendingAck.macroLabel ?? agc.pendingAck.macroId ?? ''}`));
+  }
+
+  if (Array.isArray(agc.registers) && agc.registers.length > 0) {
+    const list = document.createElement('ul');
+    list.className = 'inline-list';
+    agc.registers.forEach((reg) => {
+      const chip = document.createElement('li');
+      chip.className = 'chip';
+      const value = reg.value != null ? String(reg.value) : '--';
+      chip.textContent = `${reg.label ?? reg.id ?? 'REG'} ${value}`;
+      list.appendChild(chip);
+    });
+    fragment.appendChild(list);
+  }
+
+  if (Array.isArray(agc.history) && agc.history.length > 0) {
+    const historyList = document.createElement('ul');
+    historyList.className = 'list';
+    agc.history.forEach((entry) => {
+      const item = document.createElement('li');
+      item.className = 'list-item';
+      item.appendChild(createParagraph(`${entry.macroLabel ?? entry.macroId ?? 'Macro'} @ ${entry.get ?? '--:--:--'}`));
+      if (Array.isArray(entry.issues) && entry.issues.length > 0) {
+        item.appendChild(createParagraph(`Issues: ${entry.issues.join(', ')}`));
+      }
+      historyList.appendChild(item);
+    });
+    fragment.appendChild(historyList);
+  }
+
+  container.appendChild(fragment);
+}
+
+function renderManualQueue(queue) {
+  const container = dom.controls.manual;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!queue) {
+    container.textContent = 'No manual actions queued.';
+    return;
+  }
+  const metrics = [
+    `Pending ${queue.pending ?? 0}`,
+    `Executed ${queue.executed ?? 0}`,
+    `Failed ${queue.failed ?? 0}`,
+  ];
+  container.appendChild(createParagraph(metrics.join(' · ')));
+}
+
+function renderSystemsView() {
+  const frame = state.currentFrame;
+  renderResourceOverview(frame?.resources);
+  renderThermalComms(frame?.resources, frame?.entry);
+  renderPerformance(frame?.performance, frame?.audio);
+}
+
+function renderResourceOverview(resources) {
+  const container = dom.systems.resources;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  if (!resources) {
+    container.textContent = 'No resource data.';
+    return;
+  }
+  const grid = document.createElement('div');
+  grid.className = 'progress-grid';
+
+  if (resources.power) {
+    grid.appendChild(createTile('Power margin', resources.power.marginPct != null ? `${formatNumber(resources.power.marginPct, { digits: 1 })}%` : '—'));
+  }
+  if (resources.deltaV) {
+    grid.appendChild(createTile('Δv remaining', resources.deltaV.totalMps != null ? `${formatNumber(resources.deltaV.totalMps, { digits: 0 })} m/s` : '—'));
+  }
+  const tanks = resources.propellant?.tanks ?? {};
+  Object.values(tanks).forEach((tank) => {
+    const label = tank.label ?? 'Propellant';
+    const value = tank.percentRemaining != null
+      ? `${formatNumber(tank.percentRemaining, { digits: 0 })}%`
+      : tank.remainingKg != null
+        ? `${formatNumber(tank.remainingKg, { digits: 0 })} kg`
+        : '—';
+    grid.appendChild(createTile(label, value));
+  });
+  container.appendChild(grid);
+}
+
+function renderThermalComms(resources, entry) {
+  const container = dom.systems.thermal;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  const lines = [];
+  const thermal = resources?.thermal;
+  if (thermal) {
+    const rate = thermal.cryoBoiloffRatePctPerHr != null
+      ? `${formatNumber(thermal.cryoBoiloffRatePctPerHr, { digits: 2 })}%/hr`
+      : '—';
+    lines.push(`Cryo boil-off ${rate}`);
+    lines.push(`PTC ${thermal.ptcActive ? 'Active' : 'Idle'}`);
+  }
+  const comms = resources?.communications;
+  if (comms) {
+    if (comms.current?.station) {
+      lines.push(`Comms ${comms.current.station}`);
+    } else if (comms.nextWindowOpenGet) {
+      lines.push(`Next comms ${comms.nextWindowOpenGet}`);
+    }
+  }
+  if (entry?.entryInterfaceGet) {
+    lines.push(`Entry interface ${entry.entryInterfaceGet}`);
+  }
+  container.appendChild(createParagraph(lines.join(' · ') || 'No telemetry yet.'));
+}
+
+function renderPerformance(performance, audio) {
+  const container = dom.systems.performance;
+  if (!container) {
+    return;
+  }
+  container.textContent = '';
+  const parts = [];
+  if (performance?.tick?.averageMs != null) {
+    parts.push(`Tick ${formatNumber(performance.tick.averageMs, { digits: 2 })} ms avg`);
+  }
+  if (performance?.hud?.drops != null) {
+    parts.push(`HUD drops ${performance.hud.drops}`);
+  }
+  if (audio?.binder) {
+    parts.push(`Audio pending ${audio.binder.pendingCount ?? 0}`);
+  }
+  container.appendChild(createParagraph(parts.length > 0 ? parts.join(' · ') : 'Performance data unavailable.'));
+}
+
+function renderMissionLog() {
+  const list = dom.missionLog;
+  if (!list) {
+    return;
+  }
+  list.textContent = '';
+  const entries = state.currentFrame?.missionLog?.entries ?? [];
+  if (entries.length === 0) {
+    const item = document.createElement('li');
+    item.className = 'log-entry';
+    item.textContent = 'Mission log idle.';
+    list.appendChild(item);
+    return;
+  }
+  entries.forEach((entry) => {
+    const item = document.createElement('li');
+    item.className = `log-entry ${entry.severity ?? 'info'}`;
+    const timestamp = document.createElement('div');
+    timestamp.className = 'timestamp';
+    timestamp.textContent = entry.get ?? '--:--:--';
+    item.appendChild(timestamp);
+    item.appendChild(createParagraph(entry.message ?? '')); 
+    if (entry.source) {
+      const source = document.createElement('div');
+      source.className = 'timestamp';
+      source.textContent = entry.source;
+      item.appendChild(source);
+    }
+    list.appendChild(item);
+  });
+  list.scrollTop = list.scrollHeight;
+}
+
+function renderSummary() {
+  if (!dom.summary) {
+    return;
+  }
+  const summary = state.summary;
+  if (!summary) {
+    if (state.status === 'running' || state.status === 'connecting') {
+      dom.summary.textContent = 'Mission simulation running…';
+    } else if (state.status === 'error') {
+      dom.summary.textContent = 'Simulation error. Restart to retry.';
+    } else if (state.status === 'complete') {
+      dom.summary.textContent = 'Mission complete.';
+    } else {
+      dom.summary.textContent = 'Mission summary will appear here.';
+    }
+    return;
+  }
+
+  const grade = summary.score?.rating?.grade ?? '—';
+  const commanderScore = summary.score?.rating?.commanderScore;
+  const events = summary.events ?? {};
+  const parts = [];
+  parts.push(`Final GET ${summary.finalGet ?? '--:--:--'}`);
+  parts.push(`Grade ${grade}`);
+  if (commanderScore != null) {
+    parts.push(`Commander ${formatNumber(commanderScore, { digits: 1 })}`);
+  }
+  const completed = events.complete ?? events.completed ?? 0;
+  const total = events.total ?? events.pending ?? null;
+  if (total != null) {
+    parts.push(`Events ${completed}/${total}`);
+  }
+  dom.summary.textContent = parts.join(' · ');
+}
+
+function createParagraph(text) {
+  const p = document.createElement('p');
+  p.textContent = text;
+  return p;
+}
+
+function createTile(label, value) {
+  const tile = document.createElement('div');
+  tile.className = 'progress-tile';
+  const labelEl = document.createElement('span');
+  labelEl.className = 'label';
+  labelEl.textContent = label;
+  const valueEl = document.createElement('span');
+  valueEl.className = 'value';
+  valueEl.textContent = value;
+  tile.appendChild(labelEl);
+  tile.appendChild(valueEl);
+  return tile;
+}
+
+function createListItem(text) {
+  const item = document.createElement('li');
+  item.className = 'list-item';
+  item.textContent = text;
+  return item;
+}
+
+function setText(element, value) {
+  if (!element) {
+    return;
+  }
+  element.textContent = value;
+}
+
+function mapStatus(status) {
+  switch (status) {
+    case 'connecting':
+      return 'Connecting';
+    case 'running':
+      return 'Running';
+    case 'complete':
+      return 'Complete';
+    case 'error':
+      return 'Error';
+    case 'aborted':
+      return 'Stopped';
+    case 'unsupported':
+      return 'Unsupported';
+    default:
+      return 'Idle';
+  }
+}
+
+function computeProgress(currentSeconds, targetSeconds) {
+  if (!Number.isFinite(currentSeconds) || !Number.isFinite(targetSeconds) || targetSeconds <= 0) {
+    return null;
+  }
+  const percent = Math.min(100, Math.max(0, (currentSeconds / targetSeconds) * 100));
+  return Math.round(percent);
+}
+
+function formatNumber(value, { digits = 0 } = {}) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return Number(value).toFixed(digits);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/js/public/index.html
+++ b/js/public/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Apollo 11 Mission HUD</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="hud" aria-live="polite">
+        <div class="hud-col">
+          <div class="hud-label">GET</div>
+          <div class="hud-value" id="hud-get">--:--:--</div>
+          <div class="hud-subvalue" id="hud-met">MET --:--:--</div>
+        </div>
+        <div class="hud-col">
+          <div class="hud-label">Next Event</div>
+          <div class="hud-value" id="hud-next">Initializing…</div>
+          <div class="hud-subvalue" id="hud-next-pad"></div>
+        </div>
+        <div class="hud-col">
+          <div class="hud-label">Resources</div>
+          <div class="hud-metrics">
+            <div class="metric">
+              <span class="metric-label">Power</span>
+              <span class="metric-value" id="hud-power">--%</span>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Δv</span>
+              <span class="metric-value" id="hud-delta-v">-- m/s</span>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Comms</span>
+              <span class="metric-value" id="hud-comms">—</span>
+            </div>
+          </div>
+        </div>
+        <div class="hud-col">
+          <div class="hud-label">Score</div>
+          <div class="hud-value" id="hud-score">--</div>
+          <div class="hud-subvalue" id="hud-score-detail">Commander score</div>
+        </div>
+        <div class="hud-col">
+          <div class="hud-label">Status</div>
+          <div class="hud-value" id="hud-status">Waiting</div>
+          <div
+            class="progress-bar"
+            role="progressbar"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="0"
+            aria-label="Mission progress"
+          >
+            <div class="progress-fill" id="hud-progress"></div>
+          </div>
+        </div>
+      </header>
+
+      <section class="alert-banner" id="alert-banner" aria-live="assertive"></section>
+
+      <nav class="view-tabs" aria-label="Mission views">
+        <button type="button" class="tab-button active" data-view="navigation">Navigation</button>
+        <button type="button" class="tab-button" data-view="controls">Controls</button>
+        <button type="button" class="tab-button" data-view="systems">Systems</button>
+      </nav>
+
+      <main class="view-container">
+        <section class="view active" id="view-navigation" aria-labelledby="tab-navigation">
+          <div class="panel">
+            <h2 id="tab-navigation">Trajectory &amp; Timeline</h2>
+            <div class="panel-body" id="nav-trajectory">No trajectory data yet.</div>
+          </div>
+          <div class="panel">
+            <h3>Upcoming Events</h3>
+            <ul class="list" id="nav-upcoming"></ul>
+          </div>
+          <div class="panel">
+            <h3>Autopilot</h3>
+            <div class="panel-body" id="nav-autopilot">Autopilot idle.</div>
+          </div>
+        </section>
+
+        <section class="view" id="view-controls" aria-labelledby="tab-controls">
+          <div class="panel">
+            <h2 id="tab-controls">Active Checklists</h2>
+            <div class="panel-body" id="controls-checklists">No active checklists.</div>
+          </div>
+          <div class="panel">
+            <h3>AGC Program</h3>
+            <div class="panel-body" id="controls-agc">Awaiting AGC state…</div>
+          </div>
+          <div class="panel">
+            <h3>Manual Queue</h3>
+            <div class="panel-body" id="controls-manual">No manual actions queued.</div>
+          </div>
+        </section>
+
+        <section class="view" id="view-systems" aria-labelledby="tab-systems">
+          <div class="panel">
+            <h2 id="tab-systems">Resource Overview</h2>
+            <div class="panel-body" id="systems-resources">No resource data.</div>
+          </div>
+          <div class="panel">
+            <h3>Thermal &amp; Communications</h3>
+            <div class="panel-body" id="systems-thermal">No telemetry yet.</div>
+          </div>
+          <div class="panel">
+            <h3>Audio &amp; Performance</h3>
+            <div class="panel-body" id="systems-performance">Performance data unavailable.</div>
+          </div>
+        </section>
+      </main>
+
+      <aside class="log-panel" aria-live="polite">
+        <h2>Mission Log</h2>
+        <ul class="log-list" id="mission-log"></ul>
+      </aside>
+
+      <footer class="footer">
+        <div class="summary" id="summary-panel">Mission summary will appear here.</div>
+        <button type="button" class="restart-button" id="restart-button">Restart Simulation</button>
+      </footer>
+    </div>
+
+    <script type="module" src="/static/app.js"></script>
+  </body>
+</html>

--- a/js/public/styles.css
+++ b/js/public/styles.css
@@ -1,0 +1,497 @@
+:root {
+  color-scheme: dark;
+  --bg: #050910;
+  --panel-bg: rgba(18, 30, 52, 0.8);
+  --panel-border: rgba(92, 122, 180, 0.2);
+  --accent: #4fc3f7;
+  --accent-strong: #00c6ff;
+  --warning: #f0b429;
+  --caution: #f57c00;
+  --failure: #ff5252;
+  --text-primary: #f2f6ff;
+  --text-muted: rgba(242, 246, 255, 0.7);
+  --log-info: rgba(79, 195, 247, 0.6);
+  --log-notice: rgba(129, 199, 132, 0.6);
+  --log-warning: rgba(240, 180, 41, 0.75);
+  --log-failure: rgba(255, 82, 82, 0.85);
+  --font-heading: 'IBM Plex Sans', 'Inter', system-ui, sans-serif;
+  --font-body: 'IBM Plex Sans', 'Inter', system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 195, 247, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(129, 199, 132, 0.08), transparent 50%),
+    linear-gradient(180deg, #020409 0%, #050910 35%, #030508 100%);
+  font-family: var(--font-body);
+  color: var(--text-primary);
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas:
+    'hud hud'
+    'alert alert'
+    'tabs tabs'
+    'main log'
+    'footer footer';
+  gap: 1.2rem;
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem) 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hud {
+  grid-area: hud;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  background: linear-gradient(135deg, rgba(12, 24, 42, 0.88), rgba(8, 15, 28, 0.88));
+  border: 1px solid rgba(79, 195, 247, 0.2);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.hud-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.hud-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hud-value {
+  font-size: clamp(1.5rem, 2.2vw, 1.9rem);
+  font-weight: 600;
+  font-family: var(--font-heading);
+}
+
+.hud-subvalue {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.hud-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.metric {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.metric-label {
+  color: var(--text-muted);
+}
+
+.metric-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 0.65rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, rgba(79, 195, 247, 0.9), rgba(0, 198, 255, 0.9));
+  transition: width 0.4s ease;
+}
+
+.alert-banner {
+  grid-area: alert;
+  min-height: 0;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  display: none;
+}
+
+.alert-banner.active {
+  display: block;
+}
+
+.alert-banner.warning {
+  border-color: rgba(240, 180, 41, 0.6);
+  background: rgba(240, 180, 41, 0.12);
+}
+
+.alert-banner.failure {
+  border-color: rgba(255, 82, 82, 0.65);
+  background: rgba(255, 82, 82, 0.12);
+}
+
+.view-tabs {
+  grid-area: tabs;
+  display: flex;
+  gap: 0.75rem;
+  background: rgba(10, 18, 32, 0.7);
+  border-radius: 999px;
+  padding: 0.4rem;
+  border: 1px solid rgba(79, 195, 247, 0.18);
+}
+
+.tab-button {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.1rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  color: var(--text-primary);
+  background: rgba(79, 195, 247, 0.14);
+  outline: none;
+}
+
+.tab-button.active {
+  background: linear-gradient(135deg, rgba(79, 195, 247, 0.35), rgba(0, 198, 255, 0.25));
+  color: var(--text-primary);
+  box-shadow: 0 6px 18px rgba(0, 198, 255, 0.18);
+}
+
+.view-container {
+  grid-area: main;
+  display: grid;
+  gap: 1rem;
+}
+
+.view {
+  display: none;
+  gap: 1rem;
+}
+
+.view.active {
+  display: grid;
+  gap: 1rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+
+.panel h2,
+.panel h3 {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-heading);
+  letter-spacing: 0.04em;
+}
+
+.panel h2 {
+  font-size: 1.25rem;
+}
+
+.panel h3 {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.panel-body {
+  font-size: 0.98rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.list-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(79, 195, 247, 0.1);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.list-item strong {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid rgba(79, 195, 247, 0.25);
+}
+
+.badge.warning {
+  color: var(--warning);
+  border-color: rgba(240, 180, 41, 0.45);
+}
+
+.badge.caution {
+  color: var(--caution);
+  border-color: rgba(245, 124, 0, 0.4);
+}
+
+.badge.failure {
+  color: var(--failure);
+  border-color: rgba(255, 82, 82, 0.5);
+}
+
+.log-panel {
+  grid-area: log;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.log-panel h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-family: var(--font-heading);
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: clamp(320px, 45vh, 480px);
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.log-entry {
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-left: 3px solid rgba(79, 195, 247, 0.3);
+  font-size: 0.92rem;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.log-entry .timestamp {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.log-entry.info {
+  border-color: var(--log-info);
+}
+
+.log-entry.notice {
+  border-color: var(--log-notice);
+}
+
+.log-entry.caution,
+.log-entry.warning {
+  border-color: var(--log-warning);
+}
+
+.log-entry.failure {
+  border-color: var(--log-failure);
+}
+
+.footer {
+  grid-area: footer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(10, 16, 28, 0.7);
+  border: 1px solid rgba(79, 195, 247, 0.16);
+  border-radius: 16px;
+  padding: 0.9rem 1.2rem;
+}
+
+.summary {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.restart-button {
+  background: linear-gradient(135deg, rgba(79, 195, 247, 0.3), rgba(0, 198, 255, 0.35));
+  color: var(--text-primary);
+  border: 1px solid rgba(79, 195, 247, 0.4);
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.restart-button:hover,
+.restart-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 198, 255, 0.25);
+  outline: none;
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.progress-tile {
+  padding: 0.7rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(79, 195, 247, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.progress-tile .label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.progress-tile .value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.4rem;
+}
+
+.inline-list .chip {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.checklist-card {
+  display: grid;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(129, 199, 132, 0.2);
+  border-radius: 12px;
+  padding: 0.8rem 1rem;
+}
+
+.checklist-card strong {
+  font-size: 1.05rem;
+}
+
+.checklist-steps {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'hud'
+      'alert'
+      'tabs'
+      'main'
+      'log'
+      'footer';
+  }
+
+  .log-panel {
+    max-height: 40vh;
+  }
+
+  .view.active {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .hud {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hud-value {
+    font-size: 1.4rem;
+  }
+
+  .view-tabs {
+    flex-direction: column;
+    border-radius: 18px;
+  }
+
+  .tab-button {
+    width: 100%;
+  }
+
+  .footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .restart-button {
+    width: 100%;
+  }
+}

--- a/js/src/server/frameSerializer.js
+++ b/js/src/server/frameSerializer.js
@@ -1,0 +1,584 @@
+import { formatGET } from '../utils/time.js';
+
+const PROP_TANK_ORDER = ['csm_sps', 'csm_rcs', 'lm_descent', 'lm_ascent', 'lm_rcs'];
+
+export function createClientFrame(frame) {
+  if (!frame || typeof frame !== 'object') {
+    return null;
+  }
+
+  return {
+    time: frame.time ?? null,
+    events: simplifyEvents(frame.events),
+    resources: simplifyResources(frame.resources),
+    autopilot: simplifyAutopilot(frame.autopilot),
+    checklists: simplifyChecklists(frame.checklists),
+    manualQueue: simplifyManualQueue(frame.manualQueue),
+    agc: simplifyAgc(frame.agc),
+    trajectory: simplifyTrajectory(frame.trajectory),
+    docking: simplifyDocking(frame.docking),
+    entry: simplifyEntry(frame.entry),
+    alerts: simplifyAlerts(frame.alerts),
+    audio: simplifyAudio(frame.audio),
+    missionLog: simplifyMissionLog(frame.missionLog),
+    score: simplifyScore(frame.score),
+    performance: simplifyPerformance(frame.performance),
+  };
+}
+
+export function createClientSummary(summary) {
+  if (!summary || typeof summary !== 'object') {
+    return null;
+  }
+  const finalGetSeconds = coerceNumber(summary.finalGetSeconds);
+  return {
+    finalGetSeconds,
+    finalGet: Number.isFinite(finalGetSeconds) ? formatGET(finalGetSeconds) : null,
+    ticks: summary.ticks ?? null,
+    events: summary.events?.counts ?? summary.events ?? null,
+    resources: summary.resources
+      ? {
+          powerMarginPct: coerceNumber(summary.resources.power_margin_pct),
+          cryoBoiloffRatePctPerHr: coerceNumber(summary.resources.cryo_boiloff_rate_pct_per_hr, 2),
+          ptcActive: summary.resources.ptc_active ?? null,
+          deltaV: summary.resources.delta_v ?? null,
+          propellantKg: summary.resources.propellant ?? null,
+          failures: summary.resources.failures ?? null,
+        }
+      : null,
+    autopilot: summary.autopilot ?? null,
+    checklists: summary.checklists ?? null,
+    missionLog: summary.missionLog ?? null,
+    panels: summary.panels ?? null,
+    audio: summary.audio ?? null,
+    docking: summary.docking ?? null,
+    performance: summary.performance ?? null,
+    score: simplifyScore(summary.score),
+  };
+}
+
+function simplifyEvents(events) {
+  if (!events || typeof events !== 'object') {
+    return null;
+  }
+  const upcoming = Array.isArray(events.upcoming)
+    ? events.upcoming.slice(0, 5).map(simplifyEvent)
+    : [];
+  return {
+    counts: events.counts ?? null,
+    next: simplifyEvent(events.next),
+    upcoming,
+  };
+}
+
+function simplifyEvent(event) {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+  return {
+    id: event.id ?? null,
+    phase: event.phase ?? null,
+    status: event.status ?? null,
+    opensAt: event.opensAt ?? null,
+    opensAtSeconds: coerceNumber(event.opensAtSeconds),
+    tMinusLabel: event.tMinusLabel ?? null,
+    tMinusSeconds: coerceNumber(event.tMinusSeconds),
+    isOverdue: Boolean(event.isOverdue),
+    pad: simplifyPad(event.pad),
+  };
+}
+
+function simplifyPad(pad) {
+  if (!pad || typeof pad !== 'object') {
+    return null;
+  }
+  const params = pad.parameters ?? {};
+  const deltaVMps = coerceNumber(
+    params.deltaVMetersPerSecond ?? (params.deltaVFtPerSec != null ? params.deltaVFtPerSec * 0.3048 : null),
+    2,
+  );
+  const entryInterface = params.entryInterface ?? {};
+  return {
+    id: pad.id ?? null,
+    purpose: pad.purpose ?? null,
+    deliveryGet: pad.delivery?.get ?? null,
+    validUntilGet: pad.validUntil?.get ?? null,
+    tig: params.tig?.get ?? null,
+    deltaVMps,
+    burnDurationSeconds: coerceNumber(params.burnDurationSeconds),
+    entryInterfaceGet: entryInterface.get ?? null,
+    notes: params.notes ?? null,
+  };
+}
+
+function simplifyResources(resources) {
+  if (!resources || typeof resources !== 'object') {
+    return null;
+  }
+  return {
+    power: resources.power
+      ? {
+          marginPct: coerceNumber(resources.power.marginPct ?? resources.power.margin_pct ?? resources.power.margin),
+          loadKw: coerceNumber(resources.power.loadKw ?? resources.power.fuel_cell_load_kw, 2),
+          outputKw: coerceNumber(resources.power.outputKw ?? resources.power.fuel_cell_output_kw, 2),
+        }
+      : null,
+    thermal: resources.thermal
+      ? {
+          cryoBoiloffRatePctPerHr: coerceNumber(resources.thermal.cryoBoiloffRatePctPerHr, 2),
+          state: resources.thermal.state ?? null,
+          ptcActive: resources.thermal.ptcActive ?? null,
+        }
+      : null,
+    communications: simplifyCommunications(resources.communications),
+    deltaV: simplifyDeltaV(resources.deltaV),
+    propellant: simplifyPropellant(resources.propellant),
+    lifeSupport: resources.lifeSupport ?? null,
+  };
+}
+
+function simplifyCommunications(communications) {
+  if (!communications || typeof communications !== 'object') {
+    return null;
+  }
+  return {
+    active: communications.active ?? null,
+    current: communications.current
+      ? {
+          station: communications.current.station ?? null,
+          timeRemainingLabel: communications.current.timeRemainingLabel ?? null,
+          signalStrengthDb: coerceNumber(communications.current.signalStrengthDb, 1),
+        }
+      : null,
+    nextWindowOpenGet: communications.nextWindowOpenGet ?? null,
+    timeUntilNextWindowLabel: communications.timeUntilNextWindowLabel ?? null,
+    lastPadId: communications.lastPadId ?? null,
+  };
+}
+
+function simplifyDeltaV(deltaV) {
+  if (!deltaV || typeof deltaV !== 'object') {
+    return null;
+  }
+  const stages = {};
+  if (deltaV.stages && typeof deltaV.stages === 'object') {
+    for (const [stageId, entry] of Object.entries(deltaV.stages)) {
+      stages[stageId] = {
+        label: entry.label ?? stageId,
+        remainingMps: coerceNumber(entry.remainingMps ?? entry.marginMps ?? entry.availableMps),
+        percentRemaining: coerceNumber(entry.percentRemaining, 1),
+        status: entry.status ?? null,
+      };
+    }
+  }
+  return {
+    totalMps: coerceNumber(deltaV.totalMps ?? deltaV.totalBaseMps ?? deltaV.totalUsableMps),
+    usedMps: coerceNumber(deltaV.usedMps),
+    recoveredMps: coerceNumber(deltaV.recoveredMps),
+    primaryStageId: deltaV.primaryStageId ?? null,
+    primaryStageMps: coerceNumber(deltaV.primaryStageMps),
+    stages,
+  };
+}
+
+function simplifyPropellant(propellant) {
+  if (!propellant || typeof propellant !== 'object') {
+    return null;
+  }
+  const tanks = {};
+  const source = propellant.tanks ?? propellant.metrics ?? {};
+  for (const tankId of PROP_TANK_ORDER) {
+    const tank = source[tankId];
+    if (!tank) {
+      continue;
+    }
+    tanks[tankId] = {
+      label: tank.label ?? formatTankLabel(tankId),
+      remainingKg: coerceNumber(tank.remainingKg),
+      percentRemaining: coerceNumber(tank.percentRemaining, 1),
+      status: tank.status ?? null,
+      percentAboveReserve: coerceNumber(tank.percentAboveReserve, 1),
+    };
+  }
+  return { tanks };
+}
+
+function simplifyAutopilot(autopilot) {
+  if (!autopilot || typeof autopilot !== 'object') {
+    return null;
+  }
+  const active = Array.isArray(autopilot.activeAutopilots)
+    ? autopilot.activeAutopilots.slice(0, 4).map((entry) => ({
+        id: entry.id ?? null,
+        label: entry.label ?? entry.id ?? null,
+        eventId: entry.eventId ?? null,
+        phase: entry.phase ?? null,
+        status: entry.status ?? null,
+        progress: coerceNumber(entry.progress, 2),
+        timeRemainingLabel: entry.timeRemainingLabel ?? null,
+        pad: simplifyPad(entry.pad),
+      }))
+    : [];
+  return {
+    counts: {
+      active: autopilot.active ?? autopilot.activeCount ?? 0,
+      started: autopilot.started ?? autopilot.startedCount ?? 0,
+      completed: autopilot.completed ?? autopilot.completedCount ?? 0,
+      aborted: autopilot.aborted ?? autopilot.abortedCount ?? 0,
+    },
+    primary: autopilot.primary
+      ? {
+          id: autopilot.primary.id ?? null,
+          label: autopilot.primary.label ?? autopilot.primary.id ?? null,
+          status: autopilot.primary.status ?? null,
+          progress: coerceNumber(autopilot.primary.progress, 2),
+          timeRemainingLabel: autopilot.primary.timeRemainingLabel ?? null,
+          pad: simplifyPad(autopilot.primary.pad),
+        }
+      : null,
+    totals: {
+      burnSeconds: coerceNumber(autopilot.totalBurnSeconds),
+      ullageSeconds: coerceNumber(autopilot.totalUllageSeconds),
+      rcsImpulseNs: coerceNumber(autopilot.totalRcsImpulseNs),
+    },
+    active,
+  };
+}
+
+function simplifyChecklists(checklists) {
+  if (!checklists || typeof checklists !== 'object') {
+    return null;
+  }
+  const active = Array.isArray(checklists.active)
+    ? checklists.active.map((entry) => ({
+        checklistId: entry.checklistId ?? entry.id ?? null,
+        title: entry.title ?? entry.checklistId ?? null,
+        eventId: entry.eventId ?? null,
+        crewRole: entry.crewRole ?? null,
+        completedSteps: entry.completedSteps ?? 0,
+        totalSteps: entry.totalSteps ?? null,
+        nextStepNumber: entry.nextStepNumber ?? null,
+        nextStepAction: entry.nextStepAction
+          ?? entry.nextStepDefinition?.callout
+          ?? entry.nextStepDefinition?.notes
+          ?? null,
+        autoAdvancePending: entry.autoAdvancePending ?? null,
+        pad: simplifyPad(entry.pad),
+        tags: Array.isArray(entry.definition?.tags) ? entry.definition.tags.slice(0, 6) : undefined,
+      }))
+    : [];
+  const chip = checklists.chip
+    ? {
+        checklistId: checklists.chip.checklistId ?? null,
+        eventId: checklists.chip.eventId ?? null,
+        title: checklists.chip.title ?? null,
+        nextStepNumber: checklists.chip.nextStepNumber ?? null,
+        nextStepAction: checklists.chip.nextStepAction ?? null,
+        stepsRemaining: checklists.chip.stepsRemaining ?? null,
+        pad: simplifyPad(checklists.chip.pad),
+      }
+    : null;
+  return {
+    totals: checklists.totals ?? null,
+    active,
+    chip,
+  };
+}
+
+function simplifyManualQueue(queue) {
+  if (!queue || typeof queue !== 'object') {
+    return null;
+  }
+  return {
+    pending: queue.pending ?? 0,
+    scheduled: queue.scheduled ?? null,
+    executed: queue.executed ?? null,
+    failed: queue.failed ?? null,
+    retried: queue.retried ?? null,
+    acknowledgedSteps: queue.acknowledgedSteps ?? null,
+    dskyEntries: queue.dskyEntries ?? null,
+    panelControls: queue.panelControls ?? null,
+  };
+}
+
+function simplifyAgc(agc) {
+  if (!agc || typeof agc !== 'object') {
+    return null;
+  }
+  const registers = Array.isArray(agc.registers)
+    ? agc.registers.slice(0, 6).map((entry) => ({
+        id: entry.id ?? null,
+        label: entry.label ?? entry.id ?? null,
+        value: entry.value ?? null,
+        units: entry.units ?? null,
+      }))
+    : [];
+  const history = Array.isArray(agc.history)
+    ? agc.history.slice(0, 5).map((entry) => ({
+        id: entry.id ?? null,
+        macroLabel: entry.macroLabel ?? entry.macroId ?? null,
+        program: entry.program ?? null,
+        verb: entry.verbLabel ?? null,
+        noun: entry.nounLabel ?? null,
+        actor: entry.actor ?? null,
+        source: entry.source ?? null,
+        get: entry.get ?? null,
+        issues: Array.isArray(entry.issues)
+          ? entry.issues.map((issue) => (typeof issue === 'string' ? issue : issue?.message ?? issue?.id ?? null))
+          : [],
+      }))
+    : [];
+  return {
+    program: agc.program ?? null,
+    annunciators: agc.annunciators ?? null,
+    registers,
+    history,
+    pendingAck: agc.pendingAck ?? null,
+    metrics: agc.metrics ?? null,
+  };
+}
+
+function simplifyTrajectory(trajectory) {
+  if (!trajectory || typeof trajectory !== 'object') {
+    return null;
+  }
+  return {
+    body: trajectory.body ?? null,
+    altitudeKm: coerceNumber(trajectory.altitude?.kilometers, 1),
+    speedKmPerSec: coerceNumber(trajectory.speed?.kilometersPerSecond, 3),
+    elements: trajectory.elements
+      ? {
+          apoapsisKm: coerceNumber(trajectory.elements.apoapsisKm, 1),
+          periapsisKm: coerceNumber(trajectory.elements.periapsisKm, 1),
+          eccentricity: coerceNumber(trajectory.elements.eccentricity, 4),
+          inclinationDeg: coerceNumber(trajectory.elements.inclinationDeg, 2),
+          periodMinutes: coerceNumber(trajectory.elements.periodMinutes, 2),
+        }
+      : null,
+    metrics: trajectory.metrics ?? null,
+    alerts: simplifyAlerts(trajectory.alerts),
+  };
+}
+
+function simplifyDocking(docking) {
+  if (!docking || typeof docking !== 'object') {
+    return null;
+  }
+  return {
+    eventId: docking.eventId ?? docking.event_id ?? null,
+    activeGateId: docking.activeGateId ?? docking.activeGate ?? null,
+    progress: coerceNumber(docking.progress, 2),
+    rangeMeters: coerceNumber(docking.rangeMeters ?? docking.range_meters),
+    gates: Array.isArray(docking.gateStatuses)
+      ? docking.gateStatuses.slice(0, 4).map((gate) => ({
+          id: gate.id ?? null,
+          label: gate.label ?? null,
+          status: gate.status ?? null,
+          progress: coerceNumber(gate.progress, 2),
+          deadlineGet: gate.deadlineGet ?? null,
+        }))
+      : null,
+  };
+}
+
+function simplifyEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  return {
+    entryInterfaceGet: entry.entryInterfaceGet ?? null,
+    corridor: entry.corridor ?? null,
+    blackout: entry.blackout ?? null,
+    ems: entry.ems ?? null,
+    gLoad: entry.gLoad ?? null,
+    recovery: entry.recovery ?? null,
+  };
+}
+
+function simplifyAlerts(alerts) {
+  if (!alerts || typeof alerts !== 'object') {
+    return { warnings: [], cautions: [], failures: [] };
+  }
+  return {
+    warnings: Array.isArray(alerts.warnings) ? alerts.warnings.slice(0, 6).map(cloneShallow) : [],
+    cautions: Array.isArray(alerts.cautions) ? alerts.cautions.slice(0, 6).map(cloneShallow) : [],
+    failures: Array.isArray(alerts.failures) ? alerts.failures.slice(0, 4).map(cloneShallow) : [],
+  };
+}
+
+function simplifyAudio(audio) {
+  if (!audio || typeof audio !== 'object') {
+    return null;
+  }
+  return {
+    binder: audio.binder
+      ? {
+          totalTriggers: audio.binder.totalTriggers ?? null,
+          pendingCount: audio.binder.pendingCount ?? null,
+          lastCueId: audio.binder.lastCueId ?? null,
+          lastTriggeredAt: audio.binder.lastTriggeredAt ?? null,
+        }
+      : null,
+    dispatcher: audio.dispatcher
+      ? {
+          activeTotal: audio.dispatcher.activeTotal ?? audio.dispatcher.active?.total ?? null,
+          queuedTotal: audio.dispatcher.queuedTotal ?? audio.dispatcher.queued?.total ?? null,
+          lastStartedAt: audio.dispatcher.lastStartedAt ?? null,
+        }
+      : null,
+    pending: Array.isArray(audio.pending) ? audio.pending.slice(-4).map(simplifyAudioTrigger) : [],
+    active: Array.isArray(audio.active) ? audio.active.slice(0, 4).map(simplifyAudioTrigger) : [],
+    queued: Array.isArray(audio.queued) ? audio.queued.slice(0, 4).map(simplifyAudioTrigger) : [],
+  };
+}
+
+function simplifyAudioTrigger(trigger) {
+  if (!trigger || typeof trigger !== 'object') {
+    return null;
+  }
+  return {
+    cueId: trigger.cueId ?? null,
+    busId: trigger.busId ?? null,
+    severity: trigger.severity ?? null,
+    sourceType: trigger.sourceType ?? null,
+    triggeredAt: trigger.triggeredAt ?? null,
+  };
+}
+
+function simplifyMissionLog(log) {
+  if (!log || typeof log !== 'object') {
+    return { entries: [] };
+  }
+  const entries = Array.isArray(log.entries)
+    ? log.entries.slice(-12).map((entry) => ({
+        id: entry.id ?? null,
+        get: entry.timestampGet ?? entry.get ?? null,
+        severity: entry.severity ?? entry.logSeverity ?? 'info',
+        source: entry.source ?? entry.logSource ?? null,
+        message: entry.message ?? '',
+      }))
+    : [];
+  return {
+    entries,
+    totalCount: log.totalCount ?? entries.length,
+  };
+}
+
+function simplifyScore(score) {
+  if (!score || typeof score !== 'object') {
+    return null;
+  }
+  const rating = score.rating ?? {};
+  const history = Array.isArray(score.history)
+    ? score.history.slice(-6).map((entry) => {
+        const getLabel = entry.get != null
+          ? entry.get
+          : entry.getSeconds != null
+            ? formatMaybeGet(entry.getSeconds, entry.get)
+            : null;
+        return {
+          get: getLabel,
+          commanderScore: coerceNumber(entry.commanderScore),
+          grade: entry.grade ?? null,
+        };
+      })
+    : [];
+  return {
+    rating: {
+      commanderScore: coerceNumber(rating.commanderScore),
+      baseScore: coerceNumber(rating.baseScore),
+      manualBonus: coerceNumber(rating.manualBonus),
+      grade: rating.grade ?? null,
+      breakdown: rating.breakdown ?? null,
+    },
+    events: score.events ?? null,
+    faults: score.faults ?? null,
+    resources: score.resources
+      ? {
+          minPowerMarginPct: coerceNumber(score.resources.minPowerMarginPct, 1),
+          minDeltaVMarginMps: coerceNumber(score.resources.minDeltaVMarginMps, 1),
+          thermalViolationSeconds: coerceNumber(score.resources.thermalViolationSeconds),
+        }
+      : null,
+    history,
+  };
+}
+
+function simplifyPerformance(performance) {
+  if (!performance || typeof performance !== 'object') {
+    return null;
+  }
+  return {
+    generatedAt: performance.generatedAt ?? null,
+    overview: performance.overview ?? null,
+    tick: performance.tick
+      ? {
+          averageMs: coerceNumber(performance.tick.averageMs ?? performance.tick.average, 3),
+          maxMs: coerceNumber(performance.tick.maxMs ?? performance.tick.max, 3),
+          minMs: coerceNumber(performance.tick.minMs ?? performance.tick.min, 3),
+        }
+      : null,
+    hud: performance.hud
+      ? {
+          renderCount: performance.hud.renderCount ?? null,
+          lastRenderGet: performance.hud.lastRenderGet ?? null,
+          drops: performance.hud.drop?.total ?? null,
+        }
+      : null,
+    audio: performance.audio
+      ? {
+          lastActiveTotal: performance.audio.lastActiveTotal ?? null,
+          lastQueuedTotal: performance.audio.lastQueuedTotal ?? null,
+          maxActiveTotal: performance.audio.maxActiveTotal ?? null,
+          maxQueuedTotal: performance.audio.maxQueuedTotal ?? null,
+        }
+      : null,
+  };
+}
+
+function coerceNumber(value, decimals = null) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  if (!Number.isFinite(decimals) || decimals == null) {
+    return numeric;
+  }
+  const factor = 10 ** decimals;
+  return Math.round(numeric * factor) / factor;
+}
+
+function cloneShallow(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return entry;
+  }
+  return { ...entry };
+}
+
+function formatTankLabel(id) {
+  switch (id) {
+    case 'csm_sps':
+      return 'SPS';
+    case 'csm_rcs':
+      return 'CSM RCS';
+    case 'lm_descent':
+      return 'LM DPS';
+    case 'lm_ascent':
+      return 'LM APS';
+    case 'lm_rcs':
+      return 'LM RCS';
+    default:
+      return id?.toUpperCase?.() ?? id ?? null;
+  }
+}
+
+function formatMaybeGet(seconds, fallback) {
+  const numeric = coerceNumber(seconds);
+  if (!Number.isFinite(numeric)) {
+    return fallback ?? null;
+  }
+  return formatGET(Math.round(numeric));
+}

--- a/js/src/server/index.js
+++ b/js/src/server/index.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { startServer } from './webServer.js';
+
+function parseArgs(argv) {
+  const options = { port: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--port' || arg === '-p') {
+      const next = argv[i + 1];
+      if (!next) {
+        throw new Error('--port requires a value');
+      }
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error('--port must be a positive number');
+      }
+      options.port = parsed;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  try {
+    const { server, port } = await startServer({ port: args.port });
+    console.log(`Apollo 11 mission HUD listening on http://localhost:${port}`);
+
+    const shutdown = () => {
+      console.log('\nShutting down mission server...');
+      server.close(() => {
+        process.exit(0);
+      });
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  } catch (error) {
+    console.error('Failed to start mission HUD server:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/js/src/server/simulationStream.js
+++ b/js/src/server/simulationStream.js
@@ -1,0 +1,136 @@
+import { MissionLogger } from '../logging/missionLogger.js';
+import { createSimulationContext } from '../sim/simulationContext.js';
+import { formatGET, parseGET } from '../utils/time.js';
+import { createClientFrame, createClientSummary } from './frameSerializer.js';
+
+const DEFAULT_UNTIL_GET = '015:00:00';
+const DEFAULT_SAMPLE_SECONDS = 60;
+
+export async function handleSimulationStream(req, res, { searchParams } = {}) {
+  const params = searchParams ?? new URLSearchParams();
+  const untilParam = params.get('until');
+  const sampleParam = params.get('sample');
+  const historyParam = params.get('history');
+
+  const requestedUntil = untilParam ? parseGET(untilParam) : null;
+  const untilSeconds = Number.isFinite(requestedUntil) ? requestedUntil : parseGET(DEFAULT_UNTIL_GET);
+  const sampleSecondsRaw = sampleParam ? Number(sampleParam) : NaN;
+  const sampleSeconds = Number.isFinite(sampleSecondsRaw) && sampleSecondsRaw > 0
+    ? sampleSecondsRaw
+    : DEFAULT_SAMPLE_SECONDS;
+  const includeHistory = historyParam === '1' || historyParam === 'true';
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write('retry: 2000\n\n');
+
+  let aborted = false;
+  req.on('close', () => {
+    aborted = true;
+  });
+
+  try {
+    const logger = new MissionLogger({ silent: true });
+    const context = await createSimulationContext({
+      logger,
+      hudOptions: {
+        enabled: false,
+        upcomingLimit: 5,
+        activeChecklistLimit: 3,
+        activeAutopilotLimit: 3,
+        missionLogLimit: 20,
+        includeResourceHistory: includeHistory,
+      },
+    });
+
+    const {
+      simulation,
+      uiFrameBuilder,
+      audioBinder,
+      audioDispatcher,
+      performanceTracker,
+    } = context;
+
+    res.write(
+      `event: status\ndata: ${JSON.stringify({
+        state: 'running',
+        untilGetSeconds: untilSeconds,
+        untilGet: formatGET(untilSeconds),
+        sampleSeconds,
+        includeHistory,
+      })}\n\n`,
+    );
+
+    let lastFrameSeconds = Number.NEGATIVE_INFINITY;
+
+    const result = simulation.run({
+      untilGetSeconds: untilSeconds,
+      onTick: (tick) => {
+        if (aborted) {
+          return false;
+        }
+        const { getSeconds } = tick;
+        const shouldEmit = getSeconds - lastFrameSeconds >= sampleSeconds - 1e-6;
+        if (!shouldEmit && lastFrameSeconds !== Number.NEGATIVE_INFINITY) {
+          return true;
+        }
+
+        const performanceSnapshot = tick.performanceTracker?.snapshot
+          ? tick.performanceTracker.snapshot()
+          : performanceTracker?.snapshot?.()
+            ?? null;
+
+        const frame = uiFrameBuilder.build(getSeconds, {
+          scheduler: tick.scheduler,
+          resourceSystem: tick.resourceSystem,
+          autopilotRunner: tick.autopilotRunner,
+          checklistManager: tick.checklistManager,
+          manualQueue: tick.manualQueue,
+          rcsController: tick.rcsController,
+          agcRuntime: tick.agcRuntime,
+          scoreSystem: tick.scoreSystem,
+          orbit: tick.orbit,
+          missionLog: tick.missionLog,
+          audioBinder,
+          audioBinderStats: audioBinder?.statsSnapshot?.() ?? null,
+          audioDispatcher,
+          audioDispatcherStats: audioDispatcher?.statsSnapshot?.() ?? null,
+          docking: tick.docking?.snapshot ? tick.docking.snapshot() : null,
+          panelState: tick.panelState,
+          performance: performanceSnapshot,
+        });
+
+        const payload = createClientFrame(frame);
+        res.write(`event: frame\ndata: ${JSON.stringify(payload)}\n\n`);
+        lastFrameSeconds = getSeconds;
+        return true;
+      },
+    });
+
+    if (aborted) {
+      res.write(`event: status\ndata: ${JSON.stringify({ state: 'aborted' })}\n\n`);
+      res.end();
+      return;
+    }
+
+    const lastFrame = uiFrameBuilder.getLastFrame();
+    if (lastFrame) {
+      res.write(`event: final-frame\ndata: ${JSON.stringify(createClientFrame(lastFrame))}\n\n`);
+    }
+
+    const summaryPayload = createClientSummary(result);
+    if (summaryPayload) {
+      res.write(`event: summary\ndata: ${JSON.stringify(summaryPayload)}\n\n`);
+    }
+
+    res.write(`event: complete\ndata: ${JSON.stringify({ state: 'complete' })}\n\n`);
+    res.end();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Simulation failed';
+    res.write(`event: error\ndata: ${JSON.stringify({ message })}\n\n`);
+    res.end();
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight Node server that streams simulation frames over SSE and serves static assets
- build a Mission HUD MVP with navigation, controls, and systems views plus alert/log panels
- document the new browser workflow and add npm scripts for launching the UI demo

## Testing
- npm test
- npm run dev -- --port 3100 (manual)
- curl -s http://localhost:3100/


------
https://chatgpt.com/codex/tasks/task_e_68d2d683bfe88323bbfcd216956daa14