### PR TITLE
Add interactive checklist chip and PTC indicator to the HUD

### DIFF
--- a/js/public/index.html
+++ b/js/public/index.html
@@ -34,12 +34,24 @@
               <span class="metric-label">Comms</span>
               <span class="metric-value" id="hud-comms">—</span>
             </div>
+            <div class="metric">
+              <span class="metric-label">PTC</span>
+              <span class="metric-value ptc-indicator" id="hud-ptc">Idle</span>
+            </div>
           </div>
         </div>
         <div class="hud-col">
           <div class="hud-label">Score</div>
           <div class="hud-value" id="hud-score">--</div>
           <div class="hud-subvalue" id="hud-score-detail">Commander score</div>
+        </div>
+        <div class="hud-col hud-col-checklist">
+          <div class="hud-label">Checklist</div>
+          <button type="button" class="hud-chip" id="hud-checklist-chip" disabled>
+            <span class="chip-dot" aria-hidden="true"></span>
+            <span class="chip-label" id="hud-checklist-label">Checklist idle</span>
+          </button>
+          <div class="hud-subvalue" id="hud-checklist-detail">Auto crew standing by.</div>
         </div>
         <div class="hud-col">
           <div class="hud-label">Status</div>

--- a/js/public/styles.css
+++ b/js/public/styles.css
@@ -65,6 +65,10 @@ body {
   gap: 0.4rem;
 }
 
+.hud-col-checklist {
+  gap: 0.55rem;
+}
+
 .hud-label {
   font-size: 0.85rem;
   letter-spacing: 0.08em;
@@ -102,6 +106,91 @@ body {
 .metric-value {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+
+.ptc-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ptc-indicator::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 0 0 rgba(79, 195, 247, 0);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ptc-indicator.active::before {
+  background: rgba(79, 195, 247, 0.95);
+  box-shadow: 0 0 10px rgba(79, 195, 247, 0.35);
+}
+
+.ptc-indicator.caution::before {
+  background: rgba(245, 124, 0, 0.95);
+  box-shadow: 0 0 10px rgba(245, 124, 0, 0.3);
+}
+
+.ptc-indicator.warning::before {
+  background: rgba(255, 82, 82, 0.95);
+  box-shadow: 0 0 10px rgba(255, 82, 82, 0.35);
+}
+
+.hud-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 195, 247, 0.3);
+  background: rgba(79, 195, 247, 0.08);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  appearance: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.hud-chip:disabled {
+  opacity: 0.55;
+  cursor: default;
+  background: rgba(79, 195, 247, 0.05);
+}
+
+.hud-chip:not(:disabled):hover,
+.hud-chip:not(:disabled):focus-visible {
+  background: rgba(79, 195, 247, 0.18);
+  border-color: rgba(79, 195, 247, 0.5);
+  color: var(--text-primary);
+  box-shadow: 0 10px 24px rgba(0, 198, 255, 0.18);
+  outline: none;
+}
+
+.hud-chip.active {
+  background: linear-gradient(135deg, rgba(79, 195, 247, 0.3), rgba(0, 198, 255, 0.22));
+  border-color: rgba(79, 195, 247, 0.55);
+  color: var(--text-primary);
+  box-shadow: 0 12px 28px rgba(0, 198, 255, 0.22);
+}
+
+.hud-chip .chip-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 rgba(79, 195, 247, 0);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hud-chip.active .chip-dot {
+  background: rgba(79, 195, 247, 0.95);
+  box-shadow: 0 0 10px rgba(79, 195, 247, 0.35);
 }
 
 .progress-bar {
@@ -434,10 +523,17 @@ body {
   border: 1px solid rgba(129, 199, 132, 0.2);
   border-radius: 12px;
   padding: 0.8rem 1rem;
+  scroll-margin: 1.2rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .checklist-card strong {
   font-size: 1.05rem;
+}
+
+.checklist-card.highlight {
+  border-color: rgba(79, 195, 247, 0.55);
+  box-shadow: 0 0 0 2px rgba(79, 195, 247, 0.25), 0 14px 32px rgba(0, 198, 255, 0.18);
 }
 
 .checklist-steps {


### PR DESCRIPTION
## Summary
- add PTC status indicator and an active-checklist chip to the mission HUD markup and styles
- update the client logic to drive the PTC indicator, surface checklist details, and highlight the targeted checklist in the Controls view

## Testing
- npm start -- --until 000:05:00 --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d2eecc898c83238be5f56a7d413455