### PR TITLE
Enhance mission HUD views with maneuver context and scorecard

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -83,8 +83,10 @@ npm run dev
 
 The server streams simulation frames to the UI via Server-Sent Events. Visit [`http://localhost:3000`](http://localhost:3000) to watch the mission progress in real time. The visual MVP includes:
 
-- A persistent HUD with GET/MET, next event countdown, resource bars, comms status, and live commander score.
+- A persistent HUD with GET/MET, next event countdown, resource bars, comms status, maneuver status, and live commander score.
 - Three views—Navigation, Controls, and Systems—mirroring the project plan's layout. Tabs toggle between trajectory/timeline context, checklist & AGC details, and resource/performance telemetry.
+- Navigation view panels for docking progress and the entry corridor summarize rendezvous gates, blackout timing, and recovery milestones as the mission advances.
+- Systems view adds a commander scorecard and resource trend snapshots sourced from the simulator's history buffers.
 - Mission log feed and alert banner reacting to warnings, cautions, and failures surfaced by the simulator.
 
 Use the “Restart Simulation” button to trigger a fresh full-mission run without reloading the page. The CLI simulator remains available through `npm start` for text HUD and data exports.

--- a/js/public/index.html
+++ b/js/public/index.html
@@ -20,6 +20,11 @@
           <div class="hud-subvalue" id="hud-next-pad"></div>
         </div>
         <div class="hud-col">
+          <div class="hud-label">Maneuver</div>
+          <div class="hud-value" id="hud-maneuver">Coast</div>
+          <div class="hud-subvalue" id="hud-maneuver-detail">No programs active.</div>
+        </div>
+        <div class="hud-col">
           <div class="hud-label">Resources</div>
           <div class="hud-metrics">
             <div class="metric">
@@ -91,6 +96,14 @@
             <h3>Autopilot</h3>
             <div class="panel-body" id="nav-autopilot">Autopilot idle.</div>
           </div>
+          <div class="panel">
+            <h3>Docking</h3>
+            <div class="panel-body" id="nav-docking">Docking monitor idle.</div>
+          </div>
+          <div class="panel">
+            <h3>Entry Corridor</h3>
+            <div class="panel-body" id="nav-entry">Entry monitoring idle.</div>
+          </div>
         </section>
 
         <section class="view" id="view-controls" aria-labelledby="tab-controls">
@@ -114,12 +127,20 @@
             <div class="panel-body" id="systems-resources">No resource data.</div>
           </div>
           <div class="panel">
+            <h3>Commander Scorecard</h3>
+            <div class="panel-body" id="systems-score">Score data unavailable.</div>
+          </div>
+          <div class="panel">
             <h3>Thermal &amp; Communications</h3>
             <div class="panel-body" id="systems-thermal">No telemetry yet.</div>
           </div>
           <div class="panel">
             <h3>Audio &amp; Performance</h3>
             <div class="panel-body" id="systems-performance">Performance data unavailable.</div>
+          </div>
+          <div class="panel">
+            <h3>Resource Trends</h3>
+            <div class="panel-body" id="systems-trends">Resource history disabled.</div>
           </div>
         </section>
       </main>

--- a/js/public/styles.css
+++ b/js/public/styles.css
@@ -318,6 +318,92 @@ body {
   color: var(--text-muted);
 }
 
+.scorecard {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.score-grade {
+  font-family: var(--font-heading);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.score-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.score-metric {
+  min-width: 140px;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(79, 195, 247, 0.2);
+  background: rgba(79, 195, 247, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.score-metric .label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.score-metric .value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.score-metric .detail {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.score-breakdown {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.score-breakdown .breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.score-breakdown .label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.score-breakdown .value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.score-history {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.score-history .history-entry {
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.score-history .history-entry strong {
+  color: var(--text-primary);
+}
+
 .list {
   list-style: none;
   margin: 0;
@@ -514,6 +600,37 @@ body {
   font-size: 0.75rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+}
+
+.mini-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.mini-list li {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(79, 195, 247, 0.12);
+  border-radius: 10px;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.mini-list li strong {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.mini-list .item-meta {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .checklist-card {


### PR DESCRIPTION
## Summary
- add a maneuver column to the HUD and expose docking, entry, and commander score data in the browser HUD
- expand the Navigation view with docking and entry status panels while bringing resource history into the Systems view
- implement a commander scorecard, resource trend summaries, and supporting styling/helpers for the visual MVP

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d33491be848323a28490dab333ef4e