### PR TITLE
Allow configuring mission HUD server host binding

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -91,6 +91,10 @@ The server streams simulation frames to the UI via Server-Sent Events. Visit [`h
 
 Use the “Restart Simulation” button to trigger a fresh full-mission run without reloading the page. The CLI simulator remains available through `npm start` for text HUD and data exports.
 
+> **Tip:** pass `--host 0.0.0.0` (or set the `HOST` environment variable) if you need to reach the HUD from another machine or a
+> browser running outside the container. Combine with `--port` to override the default `3000` binding when required by your
+> environment.
+
 ## Autopilot Burn Analyzer
 
 Inspect autopilot execution metrics against historical PADs and tolerance envelopes with:

--- a/js/src/server/index.js
+++ b/js/src/server/index.js
@@ -2,7 +2,7 @@
 import { startServer } from './webServer.js';
 
 function parseArgs(argv) {
-  const options = { port: null };
+  const options = { port: null, host: null };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--port' || arg === '-p') {
@@ -16,6 +16,17 @@ function parseArgs(argv) {
       }
       options.port = parsed;
       i += 1;
+    } else if (arg === '--host' || arg === '-H') {
+      const next = argv[i + 1];
+      if (!next) {
+        throw new Error('--host requires a value');
+      }
+      const trimmed = next.trim();
+      if (!trimmed) {
+        throw new Error('--host requires a value');
+      }
+      options.host = trimmed;
+      i += 1;
     }
   }
   return options;
@@ -24,8 +35,10 @@ function parseArgs(argv) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   try {
-    const { server, port } = await startServer({ port: args.port });
-    console.log(`Apollo 11 mission HUD listening on http://localhost:${port}`);
+    const { server, port, host } = await startServer({ port: args.port, host: args.host });
+    const displayHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+    const bindingLabel = host && host !== displayHost ? ` (bound to ${host})` : '';
+    console.log(`Apollo 11 mission HUD listening on http://${displayHost}:${port}${bindingLabel}`);
 
     const shutdown = () => {
       console.log('\nShutting down mission server...');


### PR DESCRIPTION
## Summary
- add a `--host` CLI flag (and env variable support) to the mission HUD dev server so it can bind beyond localhost
- default the server binding to `0.0.0.0`, surface the resolved host in the startup log, and guard async startup errors
- document how to expose the HUD to remote browsers in the JS workspace README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33e857c3883238ab3669a26f25618