### PR TITLE
Refine HUD pacing presets

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -91,7 +91,7 @@ The server streams simulation frames to the UI via Server-Sent Events. Visit [`h
 
 Use the “Restart Simulation” button to trigger a fresh full-mission run without reloading the page. The CLI simulator remains available through `npm start` for text HUD and data exports.
 
-The development server now replays the entire Apollo 11 timeline (to GET `196:00:00`) instead of stopping after the first coast segment. The footer playback selector throttles the stream at 1×, 2×, 4×, 8×, or 16× pacing, while the **Fast (dev)** option removes pacing for regression sweeps. Each preset now also tunes the mission sampling window so the HUD receives frequent state frames without overwhelming the browser, and higher-rate settings keep the HUD ticking with ~50 ms or faster refresh intervals so countdowns and resource bars remain responsive while the mission advances.
+The development server now replays the entire Apollo 11 timeline (to GET `196:00:00`) instead of stopping after the first coast segment. The footer playback selector throttles the stream at 1×, 2×, 4×, 8×, or 16× pacing, while the **Fast (dev)** option removes pacing for regression sweeps. Each preset drives a 10 Hz Server-Sent Events stream with sampling windows between 3 s and 48 s of GET, so the baseline run completes in roughly 6½ hours of wall-clock time and the fastest preset reaches splashdown in about 25 minutes—all while the HUD refreshes every ~100 ms to keep countdowns, checklists, and resource bars responsive.
 
 > **Tip:** The mission HUD binds to `0.0.0.0` by default. Pass `--host` and `--port` if you need to target a specific interface or port when running outside the container.
 

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -3,45 +3,45 @@ const DEFAULT_SPEED_KEY = 'real';
 const SPEED_OPTIONS = [
   {
     key: 'real',
-    label: '1× (real time)',
-    intervalMs: 1000,
-    sampleSeconds: 30,
-    description: 'Full-fidelity real-time pacing.',
+    label: '1× (baseline)',
+    intervalMs: 100,
+    sampleSeconds: 3,
+    description: 'Nominal pacing with 10 Hz UI refresh (≈6.5 h full mission).',
   },
   {
     key: '2x',
     label: '2×',
-    intervalMs: 500,
-    sampleSeconds: 20,
-    description: 'Comfortable time compression for reviews.',
+    intervalMs: 100,
+    sampleSeconds: 6,
+    description: 'Double-speed playback (≈3.3 h full mission).',
   },
   {
     key: '4x',
     label: '4×',
-    intervalMs: 250,
+    intervalMs: 100,
     sampleSeconds: 12,
-    description: 'Great for mission overviews.',
+    description: 'Mission tour in about 98 minutes.',
   },
   {
     key: '8x',
     label: '8×',
-    intervalMs: 125,
-    sampleSeconds: 8,
-    description: 'Rapid scrubbing through coast phases.',
+    intervalMs: 100,
+    sampleSeconds: 24,
+    description: 'Full mission in under an hour.',
   },
   {
     key: '16x',
     label: '16×',
-    intervalMs: 62.5,
-    sampleSeconds: 4,
-    description: 'High-speed review of long coast arcs.',
+    intervalMs: 100,
+    sampleSeconds: 48,
+    description: 'Sprint through the mission in ~25 minutes.',
   },
   {
     key: 'fast',
     label: 'Fast (dev)',
     intervalMs: 0,
-    sampleSeconds: 8,
-    description: 'Uncapped simulation speed for regression runs.',
+    sampleSeconds: 12,
+    description: 'Uncapped simulation speed for regression sweeps.',
   },
 ];
 
@@ -488,6 +488,14 @@ function updateSpeedHint(config = null) {
       parts.push(`~${formatNumber(missionSample, { digits })} s GET per frame`);
     } else {
       parts.push(`~${formatNumber(missionSample, { digits: 2 })} s GET per frame`);
+    }
+  }
+
+  const missionRate = computeMissionRate(missionSample, interval);
+  if (missionRate != null) {
+    const rateLabel = formatMissionRateLabel(missionRate);
+    if (rateLabel) {
+      parts.push(rateLabel);
     }
   }
 
@@ -1907,6 +1915,29 @@ function formatDuration(seconds) {
     parts.push(`${secs}s`);
   }
   return parts.join(' ');
+}
+
+function computeMissionRate(sampleSeconds, intervalMs) {
+  if (!Number.isFinite(sampleSeconds) || sampleSeconds <= 0) {
+    return null;
+  }
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return null;
+  }
+  return (sampleSeconds * 1000) / intervalMs;
+}
+
+function formatMissionRateLabel(rate) {
+  if (!Number.isFinite(rate) || rate <= 0) {
+    return '';
+  }
+  let digits = 2;
+  if (rate >= 100) {
+    digits = 0;
+  } else if (rate >= 10) {
+    digits = 1;
+  }
+  return `Mission ≈ ${formatNumber(rate, { digits })}× real time`;
 }
 
 function formatRangeMeters(value) {


### PR DESCRIPTION
## Summary
- Reworked the mission stream presets so each option exposes a 10 Hz SSE cadence with tuned sampling windows and consistent defaults between the server and UI.
- Synced the HUD speed selector and hint copy with the new presets while surfacing the effective mission time compression for each mode.
- Documented the refreshed pacing behaviour and runtimes for the development server in the JS workspace README.

## Testing
- npm run check --prefix js
- npm test --prefix js


------
https://chatgpt.com/codex/tasks/task_e_68d34bc9e4dc832389cf973a6e20207b