### PR TITLE
Tune mission HUD pacing controls

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -91,7 +91,7 @@ The server streams simulation frames to the UI via Server-Sent Events. Visit [`h
 
 Use the “Restart Simulation” button to trigger a fresh full-mission run without reloading the page. The CLI simulator remains available through `npm start` for text HUD and data exports.
 
-The development server now replays the entire Apollo 11 timeline (to GET `196:00:00`) instead of stopping after the first coast segment. The footer playback selector throttles the stream at 1×, 2×, 4×, 8×, or 16× pacing, while the **Fast (dev)** option removes pacing for regression sweeps. Each preset drives a 10 Hz Server-Sent Events stream with sampling windows between 1.5 s and 24 s of GET, so the baseline run completes in roughly 13 hours of wall-clock time, 16× pacing lands in just under 50 minutes, and the dev preset races to splashdown as fast as the host CPU allows—all while the HUD refreshes every ~100 ms to keep countdowns, checklists, and resource bars responsive.
+The development server now replays the entire Apollo 11 timeline (to GET `196:00:00`) instead of stopping after the first coast segment. The footer playback selector throttles the stream at 1×, 2×, 4×, 8×, or 16× pacing, while the **Fast (dev)** option removes pacing for regression sweeps. Each preset keeps the HUD’s ~100 ms refresh loop while the simulator’s mission clock advances at the selected multiplier: 1× mirrors the historical GET (≈8.2 days of wall time), 2× halves that, 4× quarters it, and 16× lands in roughly 12¼ hours. Use the Fast preset when you need the simulation to sprint to splashdown as quickly as the host CPU allows.
 
 > **Tip:** The mission HUD binds to `0.0.0.0` by default. Pass `--host` and `--port` if you need to target a specific interface or port when running outside the container.
 


### PR DESCRIPTION
## Summary
- pace the simulation stream with mission-rate aware presets so the 1×/2×/4×/8×/16× options map to real-time multiples while still supporting the fast developer mode
- surface the new pacing metadata to the web HUD, refresh the playback selector copy, and keep the GET clock interpolation smooth under the revised cadence
- document the revised mission playback behaviour and durations in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d359671e10832391ab9a47c442ae5b